### PR TITLE
[PCCP-3212] Enable Embedded to plugin and Plugin to embedded code workflow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,6 +134,10 @@ test {
 tasks.assemble.dependsOn tasks.shadowJar
 
 
+shadowJar {
+	archiveClassifier.set('all')
+}
+
 artifactory {
 	publish {
 		// Define the Artifactory URL for publishing artifacts

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.1.0
+version=1.0.0-SNAPSHOT
 morpheusApiVersion=1.2.9
 morpheusGradleVersion=1.2.5-SNAPSHOT
 minVersion=8.0.3

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmPlugin.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmPlugin.groovy
@@ -43,6 +43,9 @@ class ScvmmPlugin extends Plugin {
 		List<String> seedsToRun = [
 			"application.ZoneTypesSCVMMSeed",
 			"application.ProvisionTypeScvmmSeed",
+            "application.ScvmmSeed",
+            "application.ComputeServerTypeScvmmSeed",
+            "application.ScvmmComputeTypeSeed",
 		]
 		this.morpheus.services.seed.reinstallSeedData(seedsToRun)
 		// needs to be synchronous to prevent seeds from running during plugin install

--- a/src/main/resources/scribe/scvmm-compute-types.scribe
+++ b/src/main/resources/scribe/scvmm-compute-types.scribe
@@ -47,7 +47,7 @@ resource "compute-server-type" "scvmm-linux" {
   containerEngine      = "docker"
   viewSet              = "docker"
   containerMode        = "docker"
-  isEmbedded           = true
+  isEmbedded           = false
   provisionType        = "scvmm"
   computeType          = "docker-host"
   optionTypes = [


### PR DESCRIPTION
This PR also includes some minot changes required for CI

```
NOTE: There is no implementation available for provision type scvmm-hypervisor in embedded code hence its state is unchanged in plugin mode.

Before plugin loaded:

Database changed
mysql> select is_plugin,is_embedded, code from compute_server_type where code LIKE "%scvmm%";
+----------------------+--------------------------+-----------------+
| is_plugin            | is_embedded              | code            |
+----------------------+--------------------------+-----------------+
| NULL                 | 0x00                     | scvmmController |
| NULL                 | 0x00                     | scvmmHypervisor |
| NULL                 | 0x00                     | scvmmWindows    |
| NULL                 | 0x00                     | scvmmVm         |
| NULL                 | 0x00                     | scvmmWindowsVm  |
| NULL                 | 0x00                     | scvmmUnmanaged  |
| NULL                 | 0x00                     | scvmmLinux      |
| NULL                 | 0x00                     | scvmmKubeMaster |
| NULL                 | 0x00                     | scvmmKubeWorker |
+----------------------+--------------------------+-----------------+
9 rows in set (0.01 sec)

mysql> select plugin_icon_path,enabled,is_plugin,cloud,is_embedded from compute_zone_type where code="scvmm";
+------------------+------------------+----------------------+---------+--------------------------+
| plugin_icon_path | enabled          | is_plugin            | cloud   | is_embedded              |
+------------------+------------------+----------------------+---------+--------------------------+
| NULL             | 0x01             | NULL                 | private | 0x01                     |
+------------------+------------------+----------------------+---------+--------------------------+
1 row in set (0.00 sec)

mysql> select id, name, plugin_icon_path, is_plugin,code,is_embedded from provision_type where code="scvmm";
+----+-------+------------------+----------------------+-------+--------------------------+
| id | name  | plugin_icon_path | is_plugin            | code  | is_embedded              |
+----+-------+------------------+----------------------+-------+--------------------------+
| 35 | SCVMM | NULL             | NULL                 | scvmm | 0x01                     |
+----+-------+------------------+----------------------+-------+--------------------------+
1 row in set (0.02 sec)

mysql> select id, name, plugin_icon_path, is_plugin,code,is_embedded from provision_type where code="scvmm-hypervisor";
+----+------------------+------------------+----------------------+------------------+--------------------------+
| id | name             | plugin_icon_path | is_plugin            | code             | is_embedded              |
+----+------------------+------------------+----------------------+------------------+--------------------------+
| 36 | SCVMM Hypervisor | NULL             | NULL                 | scvmm-hypervisor | 0x01                     |
+----+------------------+------------------+----------------------+------------------+--------------------------+
1 row in set (0.00 sec)


===================================================================================


After plugin is loaded:
Note: Below Output A. is with the current plugin state, which has isEmbedded set to true in the scribe for scvmmLinux code, after correcting it, the output is shown at B.
A. mysql> select is_plugin,is_embedded, code from compute_server_type where code LIKE "%scvmm%";
+----------------------+--------------------------+-----------------+
| is_plugin            | is_embedded              | code            |
+----------------------+--------------------------+-----------------+
| 0x01                 | 0x00                     | scvmmController |
| 0x01                 | 0x00                     | scvmmHypervisor |
| 0x01                 | 0x00                     | scvmmWindows    |
| 0x01                 | 0x00                     | scvmmVm         |
| 0x01                 | 0x00                     | scvmmWindowsVm  |
| 0x01                 | 0x00                     | scvmmUnmanaged  |
| 0x01                 | 0x01                     | scvmmLinux      |
| 0x01                 | 0x00                     | scvmmKubeMaster |
| 0x01                 | 0x00                     | scvmmKubeWorker |
+----------------------+--------------------------+-----------------+
9 rows in set (0.01 sec)

B. mysql> select is_plugin,is_embedded, code from compute_server_type where code LIKE "%scvmm%";
+----------------------+--------------------------+-----------------+
| is_plugin            | is_embedded              | code            |
+----------------------+--------------------------+-----------------+
| 0x01                 | 0x00                     | scvmmController |
| 0x01                 | 0x00                     | scvmmHypervisor |
| 0x01                 | 0x00                     | scvmmWindows    |
| 0x01                 | 0x00                     | scvmmVm         |
| 0x01                 | 0x00                     | scvmmWindowsVm  |
| 0x01                 | 0x00                     | scvmmUnmanaged  |
| 0x01                 | 0x00                     | scvmmLinux      |
| 0x01                 | 0x00                     | scvmmKubeMaster |
| 0x01                 | 0x00                     | scvmmKubeWorker |
+----------------------+--------------------------+-----------------+
9 rows in set (0.01 sec)

mysql> select plugin_icon_path,enabled,is_plugin,cloud,is_embedded from compute_zone_type where code="scvmm";
+--------------------------+------------------+----------------------+--------+--------------------------+
| plugin_icon_path         | enabled          | is_plugin            | cloud  | is_embedded              |
+--------------------------+------------------+----------------------+--------+--------------------------+
| /plugin/scvmm//scvmm.svg | 0x01             | 0x01                 | public | 0x01                     |
+--------------------------+------------------+----------------------+--------+--------------------------+
1 row in set (0.00 sec)

mysql> select id, name, plugin_icon_path, is_plugin,code,is_embedded from provision_type where code="scvmm";
+----+-------+---------------------------------------+----------------------+-------+--------------------------+
| id | name  | plugin_icon_path                      | is_plugin            | code  | is_embedded              |
+----+-------+---------------------------------------+----------------------+-------+--------------------------+
| 35 | SCVMM | /plugin/scvmm//provision-circular.svg | 0x01                 | scvmm | 0x01                     |
+----+-------+---------------------------------------+----------------------+-------+--------------------------+
1 row in set (0.00 sec)


mysql> select id, name, plugin_icon_path, is_plugin,code,is_embedded from provision_type where code="scvmm-hypervisor";
+----+------------------+------------------+----------------------+------------------+--------------------------+
| id | name             | plugin_icon_path | is_plugin            | code             | is_embedded              |
+----+------------------+------------------+----------------------+------------------+--------------------------+
| 36 | SCVMM Hypervisor | NULL             | NULL                 | scvmm-hypervisor | 0x01                     |
+----+------------------+------------------+----------------------+------------------+--------------------------+
1 row in set (0.00 sec)


==========================================================================

After plugin uninstalled and in the Embedded mode:

mysql> select is_plugin,is_embedded, code from compute_server_type where code LIKE "%scvmm%";
+----------------------+--------------------------+-----------------+
| is_plugin            | is_embedded              | code            |
+----------------------+--------------------------+-----------------+
| 0x01                 | 0x00                     | scvmmController |
| 0x01                 | 0x00                     | scvmmHypervisor |
| 0x01                 | 0x00                     | scvmmWindows    |
| 0x01                 | 0x00                     | scvmmVm         |
| 0x01                 | 0x00                     | scvmmWindowsVm  |
| 0x01                 | 0x00                     | scvmmUnmanaged  |
| 0x01                 | 0x00                     | scvmmLinux      |
| 0x01                 | 0x00                     | scvmmKubeMaster |
| 0x01                 | 0x00                     | scvmmKubeWorker |
+----------------------+--------------------------+-----------------+
9 rows in set (0.02 sec)

mysql> 
mysql> select plugin_icon_path,enabled,is_plugin,cloud,is_embedded from compute_zone_type where code="scvmm";
+------------------+------------------+----------------------+---------+--------------------------+
| plugin_icon_path | enabled          | is_plugin            | cloud   | is_embedded              |
+------------------+------------------+----------------------+---------+--------------------------+
| NULL             | 0x01             | 0x00                 | private | 0x01                     |
+------------------+------------------+----------------------+---------+--------------------------+
1 row in set (0.01 sec)


mysql> select id, name, plugin_icon_path, is_plugin,code,is_embedded from provision_type where code="scvmm";
+----+-------+---------------------------------------+----------------------+-------+--------------------------+
| id | name  | plugin_icon_path                      | is_plugin            | code  | is_embedded              |
+----+-------+---------------------------------------+----------------------+-------+--------------------------+
| 35 | SCVMM | /plugin/scvmm//provision-circular.svg | 0x00                 | scvmm | 0x01                     |
+----+-------+---------------------------------------+----------------------+-------+--------------------------+
1 row in set (0.00 sec)

mysql> select id, name, plugin_icon_path, is_plugin,code,is_embedded from provision_type where code="scvmm-hypervisor";
+----+------------------+------------------+----------------------+------------------+--------------------------+
| id | name             | plugin_icon_path | is_plugin            | code             | is_embedded              |
+----+------------------+------------------+----------------------+------------------+--------------------------+
| 36 | SCVMM Hypervisor | NULL             | NULL                 | scvmm-hypervisor | 0x01                     |
+----+------------------+------------------+----------------------+------------------+--------------------------+
1 row in set (0.00 sec)

=============================================================================================================


```