### PR TITLE
[PCCP-5452][Dev][Plugin Issue] Cloud Compatibility Sync fails during cloud save

### DIFF
--- a/src/main/groovy/com/morpheusdata/scvmm/sync/CloudCapabilityProfilesSync.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/sync/CloudCapabilityProfilesSync.groovy
@@ -24,20 +24,21 @@ class CloudCapabilityProfilesSync {
     def execute() {
         log.debug "CloudCapabilityProfilesSync"
         try {
-            def server = morpheusContext.services.computeServer.find(new DataQuery().withFilter('cloud.id', cloud.id))
-            def scvmmOpts = apiService.getScvmmZoneAndHypervisorOpts(morpheusContext, cloud, server)
+            def scvmmCloud = morpheusContext.services.cloud.get(cloud.id)
+            def server = morpheusContext.services.computeServer.find(new DataQuery().withFilter('cloud.id', scvmmCloud.id))
+            def scvmmOpts = apiService.getScvmmZoneAndHypervisorOpts(morpheusContext, scvmmCloud, server)
 
-            if(cloud.regionCode) {
+            if(scvmmCloud.regionCode) {
                 def cloudResults = apiService.getCloud(scvmmOpts)
                 if(cloudResults.success == true && cloudResults?.cloud?.CapabilityProfiles) {
-                    cloud.setConfigProperty('capabilityProfiles', cloudResults?.cloud.CapabilityProfiles)
-                    morpheusContext.services.cloud.save(cloud)
+                    scvmmCloud.setConfigProperty('capabilityProfiles', cloudResults?.cloud?.CapabilityProfiles)
+                    morpheusContext.services.cloud.save(scvmmCloud)
                 }
             } else {
                 def capabilityProfileResults = apiService.getCapabilityProfiles(scvmmOpts)
                 if(capabilityProfileResults.success == true && capabilityProfileResults?.capabilityProfiles) {
-                    cloud.setConfigProperty('capabilityProfiles', capabilityProfileResults.capabilityProfiles.collect { it.Name })
-                    morpheusContext.services.cloud.save(cloud)
+                    scvmmCloud.setConfigProperty('capabilityProfiles', capabilityProfileResults.capabilityProfiles.collect { it.Name })
+                    morpheusContext.services.cloud.save(scvmmCloud)
                 }
             }
         } catch (e) {


### PR DESCRIPTION
This is a fix for the below error:

```
[2025-09-11 11:47:03,236] [RxCachedThreadScheduler-134] ERROR c.m.p.GormObservableFactory - An Error Occurred Performing Database Operation via Plugin Context Services: A different object with the same identifier value was already associated with the session : [com.morpheus.backup.BackupProvider#1] 
javax.persistence.EntityExistsException: A different object with the same identifier value was already associated with the session : [com.morpheus.backup.BackupProvider#1]
```

JIRA ID- [PCCP-5452 - [Dev][Plugin Issue] Cloud Compatibility Sync fails during cloud save](https://hpe.atlassian.net/browse/PCCP-5452)