### PR TITLE
MORPH-9449: Docker Cluster two volume VM goes from sda/sdb to sdc/sdd during creation

### DIFF
--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
@@ -1978,6 +1978,12 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
                             rootVolume.externalId = serverDisks.diskMetaData[serverDisks.osDisk?.externalId]?.VhdID
                             // Fix up the externalId.. initially set to the VirtualDiskDrive ID.. now setting to VirtualHardDisk ID
                             rootVolume.datastore = loadDatastoreForVolume(cloud, serverDisks.diskMetaData[rootVolume.externalId]?.HostVolumeId, serverDisks.diskMetaData[rootVolume.externalId]?.FileShareId, serverDisks.diskMetaData[rootVolume.externalId]?.PartitionUniqueId) ?: rootVolume.datastore
+                            // Sync the volume changes to the Morpheus DB
+                            log.debug("Root volume updated: " +
+                                    "name=${rootVolume.name} (${rootVolume.id}), " +
+                                    "externalId=${rootVolume.externalId}, " +
+                                    "datastore=${rootVolume.datastore?.name}")
+                            context.services.storageVolume.save(rootVolume)
                             storageVolumes.each { storageVolume ->
                                 def dataDisk = serverDisks.dataDisks.find { it.id == storageVolume.id }
                                 if (dataDisk) {
@@ -1988,6 +1994,12 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
 
                                     // Ensure the datastore is set
                                     storageVolume.datastore = loadDatastoreForVolume(cloud, serverDisks.diskMetaData[storageVolume.externalId]?.HostVolumeId, serverDisks.diskMetaData[storageVolume.externalId]?.FileShareId, serverDisks.diskMetaData[storageVolume.externalId]?.PartitionUniqueId) ?: storageVolume.datastore
+                                    // Sync the volume changes to the Morpheus DB
+                                    log.debug("Data volume updated: " +
+                                            "name=${storageVolume.name} (${storageVolume.id}), " +
+                                            "externalId=${storageVolume.externalId}, " +
+                                            "datastore=${storageVolume.datastore?.name}")
+                                    context.services.storageVolume.save(storageVolume)
                                 }
                             }
                         }

--- a/src/main/groovy/com/morpheusdata/scvmm/sync/VirtualMachineSync.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/sync/VirtualMachineSync.groovy
@@ -385,6 +385,15 @@ class VirtualMachineSync {
 
     def syncVolumes(server, externalVolumes) {
         log.debug "syncVolumes: ${server}, ${groovy.json.JsonOutput.prettyPrint(externalVolumes?.encodeAsJSON()?.toString())}"
+
+        // Log existing volumes for debugging
+        server?.volumes?.each { StorageVolume it ->
+            log.debug "Existing Morpheus volume: " +
+                    "name=${it.name} (${it.id}), " +
+                    "externalId=${it.externalId}, " +
+                    "maxStorage=${it.maxStorage}"
+        }
+
         def changes = false
         try {
             def maxStorage = 0
@@ -425,7 +434,7 @@ class VirtualMachineSync {
         def provisionProvider = cloudProvider.getProvisionProvider('morpheus-scvmm-plugin.provision')
         def serverVolumeNames = server.volumes.collect{ it.name }
         itemsToAdd?.eachWithIndex { diskData, index ->
-            log.debug("adding new volume: ${diskData}")
+            log.debug("adding new volume: ${diskData?.name} (${diskData?.id})")
             def datastore = diskData.datastore ?: loadDatastoreForVolume(diskData.HostVolumeId, diskData.FileShareId, diskData.PartitionUniqueId) ?: null
             def deviceName = diskData.deviceName ?: apiService.getDiskName(diskNumber)
             def volumeName = serverVolumeNames?.getAt(index) ?: getVolumeName(diskData, deviceName, server, index)
@@ -497,7 +506,7 @@ class VirtualMachineSync {
 
     def removeMissingStorageVolumes(removeItems, ComputeServer server, Boolean changes) {
         removeItems?.each { currentVolume ->
-            log.debug "removing volume: ${currentVolume}"
+            log.debug "removing volume: ${currentVolume?.name} (${currentVolume?.id})"
             changes = true
             currentVolume.controller = null
             currentVolume.datastore = null


### PR DESCRIPTION
This PR resolves the issue detailed in MORPH-9449. The issue is that, during VM creation, the VM's volumes transition from device sda/sdb to sdc/sdd. The root cause is that the updated Morpheus volumes were not synced to the Morpheus DB when the VM was created causing the `syncVolumes` to remove/restore them as well as incrementing their index.

With the additional logging added in this PR, we see the `externalId` added to the Morpheus volume as its synced to the DB:
```
[2026-04-03T11:44:34Z] DEBUG [appJobHigh-11] [SCVMMPlugin] [ScvmmProvisionProvider.groovy:1982] Root volume updated: name=root (383), externalId=e12c26cb-ca15-4aea-bf14-a5fc18a83490, datastore=NODE2025-3 : C:\
[2026-04-03T11:44:34Z] DEBUG [appJobHigh-11] [SCVMMPlugin] [ScvmmProvisionProvider.groovy:1998] Data volume updated: name=data (384), externalId=dffcbb3e-609e-4764-bd88-7d78cc4bf658, datastore=NODE2025-3 : C:\
```
Then, during a future refresh cloud, the `syncVolumes` detects the volume and we see the `externalId` is still aligned:
```
[2026-04-03T11:44:42Z] DEBUG [RxCachedThreadScheduler-850] [SCVMMPlugin] [VirtualMachineSync.groovy:391] Existing Morpheus volume: name=root (383), externalId=e12c26cb-ca15-4aea-bf14-a5fc18a83490, maxStorage=10737418240
[2026-04-03T11:44:42Z] DEBUG [RxCachedThreadScheduler-850] [SCVMMPlugin] [VirtualMachineSync.groovy:391] Existing Morpheus volume: name=data (384), externalId=dffcbb3e-609e-4764-bd88-7d78cc4bf658, maxStorage=11811160064
```
This PR also addresses the majority of cases where a Docker Cluster creation fails because the Morpheus agent fails to install on the VM.