### PR TITLE
MORPH-8240: Filter temporary templates from import and display

### DIFF
--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
@@ -1,16 +1,16 @@
+// Copyright 2026 Hewlett Packard Enterprise Development LP
+
 package com.morpheusdata.scvmm
 
+import com.bertramlabs.plugins.karman.CloudFile
 import com.morpheusdata.core.MorpheusContext
 import com.morpheusdata.core.data.DataQuery
 import com.morpheusdata.core.util.ComputeUtility
 import com.morpheusdata.model.Cloud
 import com.morpheusdata.model.ComputeServer
-import com.morpheusdata.model.KeyPair
 import com.morpheusdata.scvmm.logging.LogInterface
 import com.morpheusdata.scvmm.logging.LogWrapper
 import groovy.json.JsonOutput
-import groovy.util.logging.Slf4j
-import com.bertramlabs.plugins.karman.CloudFile
 
 class ScvmmApiService {
     MorpheusContext morpheusContext
@@ -683,7 +683,14 @@ foreach (\$VHDconf in \$Disks) {
         def out = wrapExecuteCommand(command, opts)
         log.debug("out: ${out.data}")
         if (out.success) {
-            rtn.templates = out.data
+            // Filter out temporary templates created by SCVMM during provisioning; not intended as user-facing options
+            rtn.templates = (out.data ?: []).findAll { template ->
+                boolean isTemporaryTemplate = (template?.Name ?: '') ==~ ScvmmConstants.TEMPORARY_TEMPLATE_UUID_PATTERN
+                if (isTemporaryTemplate) {
+                    log.debug("Filtered temporary template: ${template?.Name}")
+                }
+                !isTemporaryTemplate
+            }
             rtn.success = true
         }
         return rtn

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmConstants.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmConstants.groovy
@@ -1,0 +1,23 @@
+// Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package com.morpheusdata.scvmm
+
+import groovy.transform.CompileStatic
+
+import java.util.regex.Pattern
+
+@CompileStatic
+class ScvmmConstants {
+    /**
+     * SCVMM can create temporary VM templates with names like "Temporary Template{UUID}" while the SCVMM plugin can
+     * create temporary VM templates with names like "Temporary Morpheus Template{UUID}". These occur during
+     * provisioning or template-based deployment operations. These templates are intended to be short-lived and are
+     * normally removed automatically when the operation completes. However, if an operation fails or is interrupted,
+     * temporary templates may remain in SCVMM and clutter template listings. This regex/pattern allows the plugin to
+     * identify and ignore those leftovers.
+     */
+    static final String TEMPORARY_TEMPLATE_UUID_REGEX =
+            '^Temporary (?:Morpheus )?Template\\s*' +
+                    '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+    static final Pattern TEMPORARY_TEMPLATE_UUID_PATTERN = Pattern.compile(TEMPORARY_TEMPLATE_UUID_REGEX)
+}

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmOptionSourceProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmOptionSourceProvider.groovy
@@ -1,19 +1,17 @@
+// Copyright 2026 Hewlett Packard Enterprise Development LP
+
 package com.morpheusdata.scvmm
 
 import com.morpheusdata.core.AbstractOptionSourceProvider
 import com.morpheusdata.core.MorpheusContext
-import com.morpheusdata.core.OptionSourceProvider
 import com.morpheusdata.core.Plugin
 import com.morpheusdata.core.data.DataAndFilter
 import com.morpheusdata.core.data.DataFilter
 import com.morpheusdata.core.data.DataOrFilter
 import com.morpheusdata.core.data.DataQuery
-import com.morpheusdata.core.util.MorpheusUtils
 import com.morpheusdata.model.Cloud
-import com.morpheusdata.model.ComputeServer
 import com.morpheusdata.scvmm.logging.LogInterface
 import com.morpheusdata.scvmm.logging.LogWrapper
-import groovy.util.logging.Slf4j
 
 class ScvmmOptionSourceProvider extends AbstractOptionSourceProvider {
 
@@ -315,7 +313,17 @@ class ScvmmOptionSourceProvider extends AbstractOptionSourceProvider {
 
 		try {
 			def results = morpheusContext.services.virtualImage.listIdentityProjections(query.withSort("name", DataQuery.SortOrder.asc))
-			return results.collect { vimage -> [name: vimage.name, value: vimage.id] }
+
+			// Filter out temporary templates created by SCVMM during provisioning; not intended as user-facing options
+			def filteredResults = results.findAll { image ->
+				boolean isTemporaryTemplate = (image.name ?: '') ==~ ScvmmConstants.TEMPORARY_TEMPLATE_UUID_PATTERN
+				if (isTemporaryTemplate) {
+					log.debug("Filtered temporary template image: name=${image.name}, id=${image.id}")
+				}
+				!isTemporaryTemplate
+			}
+
+			return filteredResults.collect { vimage -> [name: vimage.name, value: vimage.id] }
 		} catch (e) {
 			log.error("scvmmVirtualImages error: ${e}", e)
 			return []

--- a/src/test/groovy/com/morpheusdata/scvmm/ScvmmConstants.groovy
+++ b/src/test/groovy/com/morpheusdata/scvmm/ScvmmConstants.groovy
@@ -1,0 +1,103 @@
+// Copyright 2026 Hewlett Packard Enterprise Development LP
+
+package com.morpheusdata.scvmm
+
+import spock.lang.Specification
+
+class ScvmmConstantsSpec extends Specification {
+    def "TEMPORARY_TEMPLATE_UUID_REGEX #description"() {
+        expect:
+        (input ==~ ScvmmConstants.TEMPORARY_TEMPLATE_UUID_PATTERN) == shouldMatch
+
+        where:
+        [description, input, shouldMatch] << [
+                // --- should match ---
+                [
+                        'Matches "Temporary Template" with no space before UUID',
+                        'Temporary Template016c811a-3c00-4c56-86ea-5b39897079b9',
+                        true,
+                ],
+                [
+                        'Matches "Temporary Template" with one space before UUID',
+                        'Temporary Template 016c811a-3c00-4c56-86ea-5b39897079b9',
+                        true,
+                ],
+                [
+                        'Matches "Temporary Template" with multiple spaces before UUID',
+                        'Temporary Template   016c811a-3c00-4c56-86ea-5b39897079b9',
+                        true,
+                ],
+                [
+                        'Matches "Temporary Morpheus Template" with no space before UUID',
+                        'Temporary Morpheus Template016c811a-3c00-4c56-86ea-5b39897079b9',
+                        true,
+                ],
+                [
+                        'Matches "Temporary Morpheus Template" with one space before UUID',
+                        'Temporary Morpheus Template 016c811a-3c00-4c56-86ea-5b39897079b9',
+                        true,
+                ],
+                [
+                        'Matches uppercase hex UUID',
+                        'Temporary Template 016C811A-3C00-4C56-86EA-5B39897079B9',
+                        true,
+                ],
+                [
+                        'Matches mixed-case hex UUID',
+                        'Temporary Template 016c811A-3C00-4c56-86Ea-5b39897079B9',
+                        true,
+                ],
+                // --- should not match ---
+                [
+                        'Does not match empty string',
+                        '',
+                        false,
+                ],
+                [
+                        'Does not match prefix only with no UUID',
+                        'Temporary Template',
+                        false,
+                ],
+                [
+                        'Does not match wrong prefix casing',
+                        'temporary template 016c811a-3c00-4c56-86ea-5b39897079b9',
+                        false,
+                ],
+                [
+                        'Does not match UUID with missing segment',
+                        'Temporary Template 016c811a-3c00-4c56-5b39897079b9',
+                        false,
+                ],
+                [
+                        'Does not match UUID without dashes',
+                        'Temporary Template 016c811a3c004c5686ea5b39897079b9',
+                        false,
+                ],
+                [
+                        'Does not match UUID with non-hex character',
+                        'Temporary Template 016c811a-3c00-4c56-86ea-5b39897079bZ',
+                        false,
+                ],
+                [
+                        'Does not match UUID with too few hex chars in first segment',
+                        'Temporary Template 016c811-3c00-4c56-86ea-5b39897079b9',
+                        false,
+                ],
+                [
+                        'Does not match trailing characters after UUID',
+                        'Temporary Template 016c811a-3c00-4c56-86ea-5b39897079b9-extra',
+                        false,
+                ],
+                [
+                        'Does not match leading characters before prefix',
+                        'X Temporary Template 016c811a-3c00-4c56-86ea-5b39897079b9',
+                        false,
+                ],
+                [
+                        'Does not match "Temporary Morpheus" without "Template"',
+                        'Temporary Morpheus 016c811a-3c00-4c56-86ea-5b39897079b9',
+                        false,
+                ],
+        ]
+    }
+}


### PR DESCRIPTION
SCVMM can create temporary VM templates with names like "Temporary Template{UUID}" while the SCVMM plugin can create temporary VM templates with names like "Temporary Morpheus Template{UUID}". These occur during provisioning or template-based deployment operations. These templates are intended to be short-live and are normally removed automatically when the operation completes. However, if an operation fails or is interrupted, temporary templates may remain in SCVMM and clutter template listings.

This PR filters the temporary templates from being imported as well as displayed (in case they were imported with older plugin version). Debug log entries are recorded for any item filtered:
```
[2026-04-13T15:49:05Z] DEBUG [http-nio-127.0.0.1-8080-exec-166] [SCVMMPlugin] [ScvmmOptionSourceProvider.groovy:321] Filtered temporary template image: name=Temporary Morpheus Template 02ab88d5-eeaa-4999-8ab4-f10884256f0f, id=256
[2026-04-13T15:49:05Z] DEBUG [http-nio-127.0.0.1-8080-exec-166] [SCVMMPlugin] [ScvmmOptionSourceProvider.groovy:321] Filtered temporary template image: name=Temporary Morpheus Template 03fd22f4-8abe-447a-9edd-9b131291ed15, id=239
[2026-04-13T15:49:05Z] DEBUG [http-nio-127.0.0.1-8080-exec-166] [SCVMMPlugin] [ScvmmOptionSourceProvider.groovy:321] Filtered temporary template image: name=Temporary Morpheus Template 06d1af40-6703-4cbd-9fc6-aba1e8d1638a, id=261
```
Unit test coverage added for the regex string.