### PR TITLE
MORPH-8233: Add description to SCVMM plugin

### DIFF
--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmPlugin.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmPlugin.groovy
@@ -1,32 +1,23 @@
-/*
-* Copyright 2022 the original author or authors.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright 2026 Hewlett Packard Enterprise Development LP
+
 package com.morpheusdata.scvmm
 
 import com.morpheusdata.core.Plugin
 
 class ScvmmPlugin extends Plugin {
+    private static final String PLUGIN_CODE = 'morpheus-scvmm-plugin'
+    private static final String PLUGIN_NAME = 'SCVMM'
+    private static final String PLUGIN_DESCRIPTION = 'Plugin for SCVMM Integration'
 
     @Override
     String getCode() {
-        return 'morpheus-scvmm-plugin'
+        return PLUGIN_CODE
     }
 
     @Override
     void initialize() {
-        this.setName("SCVMM")
+        this.setName(PLUGIN_NAME)
+        this.setDescription(PLUGIN_DESCRIPTION)
         this.registerProviders(
                 new ScvmmCloudProvider(this,this.morpheus),
                 new ScvmmProvisionProvider(this,this.morpheus),
@@ -51,5 +42,4 @@ class ScvmmPlugin extends Plugin {
 		this.morpheus.services.seed.reinstallSeedData(seedsToRun)
 		// needs to be synchronous to prevent seeds from running during plugin install
 	}
-
 }


### PR DESCRIPTION
This PR adds a description to the plugin that appears within the Integrations view:
<img width="1122" height="604" alt="image" src="https://github.com/user-attachments/assets/83dacc53-2dd0-4f08-9288-3829de914c8f" />

The acronym SCVMM was used in the description, instead of writing it fully out, to fit within the size constraints. The naming convention was made to follow other HPE plugins as shown in the DESCRIPTION column above.