### PR TITLE
chore: Log virtual image details in runHost

### DIFF
--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
@@ -1892,7 +1892,7 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
             }
 
             scvmmOpts += apiService.getScvmmControllerOpts(cloud, controllerNode)
-            def imageId
+            def imageId = null
             if (layout && typeSet) {
                 virtualImage = typeSet.workloadType.virtualImage
                 imageId = virtualImage.externalId
@@ -1904,6 +1904,9 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
 		virtualImage = new VirtualImage(code: 'scvmm.image.morpheus.ubuntu.22.04.20250218.amd64')
                 //better this later
             }
+
+            log.debug("runHost virtual image: name=${virtualImage?.name} (${virtualImage?.id}), " +
+                    "code=${virtualImage?.code}, remotePath=${virtualImage?.remotePath}, imageId=${imageId}")
 
             if (!imageId) { //If its userUploaded and still needs uploaded
                 def cloudFiles = context.async.virtualImage.getVirtualImageFiles(virtualImage).blockingGet()


### PR DESCRIPTION
Added a virtual image log entry to assist with debug analysis. Sample log entry:
```
[2026-04-15 15:06:39,265] [appJobHigh-19] DEBUG c.m.s.l.LogWrapper - [SCVMMPlugin] [ScvmmProvisionProvider.groovy:1930] runHost virtual image: name=Morpheus Ubuntu 22.04 20260115 (107), code=hyperv.image.morpheus.ubuntu.22.04.20260115.amd64, remotePath=https://s3-us-west-1.amazonaws.com/morpheus-images/hyperv/20260115/ubuntu-22/morpheus-ubuntu-22_04-amd64-20260115.vhd.tar.gz, imageId=null 
```