### PR TITLE
MORPH-8189: Add runHost and runWorkload validation

### DIFF
--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
@@ -1993,11 +1993,18 @@ For (\$i=0; \$i -le 10; \$i++) {
         log.debug("validateServerConfig: ${opts}")
         def rtn = [success: false, errors: []]
         try {
-            if (!opts.scvmmCapabilityProfile) {
-                rtn.errors += [field: 'scvmmCapabilityProfile', msg: 'You must select a capability profile']
+            // When creating an instance, the capability profile is required. When creating a Docker Cluster, there is
+            // not capability profile option. We need to check if the field is present before validating it.
+            if (opts.containsKey(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE) && !opts.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE)) {
+                rtn.errors += [field: ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE, msg: 'You must select a capability profile']
+            }
+            // When creating an instance, the template (i.e. virtual image) is required. When creating a Docker Cluster,
+            // there is no user specified virtual image. We need to check if the field is present before validating it.
+            if (opts.containsKey(ScvmmConstants.CFG_TEMPLATE) && !opts.(ScvmmConstants.CFG_TEMPLATE)) {
+                rtn.errors += [field: ScvmmConstants.CFG_TEMPLATE, msg: 'Virtual image is required']
             }
             // if(!opts.networkId && opts.networkInterfaces?.size() == 0) {
-            // 	rtn.errors += [field: 'networkInterface', msg: 'You must choose a network']
+            // 	rtn.errors += [field: ScvmmConstants.CFG_NETWORK_INTERFACE, msg: 'You must choose a network']
             // }
             if (opts.networkId) {
                 // great
@@ -2008,29 +2015,29 @@ For (\$i=0; \$i -le 10; \$i++) {
                     def networkId = nic.network?.id ?: nic.network.group
                     log.debug("network.id: ${networkId}")
                     if (!networkId) {
-                        rtn.errors << [field: 'networkInterface', msg: 'Network is required']
+                        rtn.errors << [field: ScvmmConstants.CFG_NETWORK_INTERFACE, msg: 'Network is required']
                     }
                     if (nic.ipMode == 'static' && !nic.ipAddress) {
-                        rtn.errors = [field: 'networkInterface', msg: 'You must enter an ip address']
+                        rtn.errors = [field: ScvmmConstants.CFG_NETWORK_INTERFACE, msg: 'You must enter an ip address']
                     }
                 }
-            } else if (opts?.networkInterface) {
+            } else if (opts?.containsKey(ScvmmConstants.CFG_NETWORK_INTERFACE)) {
                 // UI params
-                log.debug("validateServerConfig networkInterface: ${opts.networkInterface}")
-                toList(opts?.networkInterface?.network?.id)?.eachWithIndex { networkId, index ->
+                log.debug("validateServerConfig networkInterface: ${opts.(ScvmmConstants.CFG_NETWORK_INTERFACE)}")
+                toList(opts?.(ScvmmConstants.CFG_NETWORK_INTERFACE)?.network?.id)?.eachWithIndex { networkId, index ->
                     log.debug("network.id: ${networkId}")
                     if (networkId?.length() < 1) {
-                        rtn.errors << [field: 'networkInterface', msg: 'Network is required']
+                        rtn.errors << [field: ScvmmConstants.CFG_NETWORK_INTERFACE, msg: 'Network is required']
                     }
-                    if (networkInterface[index].ipMode == 'static' && !networkInterface[index].ipAddress) {
-                        rtn.errors = [field: 'networkInterface', msg: 'You must enter an ip address']
+                    if (opts.(ScvmmConstants.CFG_NETWORK_INTERFACE)[index].ipMode == 'static' && !opts.(ScvmmConstants.CFG_NETWORK_INTERFACE)[index].ipAddress) {
+                        rtn.errors = [field: ScvmmConstants.CFG_NETWORK_INTERFACE, msg: 'You must enter an ip address']
                     }
                 }
             } else {
-                rtn.errors << [field: 'networkId', msg: 'Network is required']
+                rtn.errors << [field: ScvmmConstants.CFG_NETWORK_ID, msg: 'Network is required']
             }
-            if (opts.containsKey('nodeCount') && opts.nodeCount == '') {
-                rtn.errors += [field: 'nodeCount', msg: 'You must indicate number of hosts']
+            if (opts.containsKey(ScvmmConstants.CFG_NODE_COUNT) && opts.(ScvmmConstants.CFG_NODE_COUNT) == '') {
+                rtn.errors += [field: ScvmmConstants.CFG_NODE_COUNT, msg: 'You must indicate number of hosts']
             }
             rtn.success = (rtn.errors.size() == 0)
             log.debug "validateServer results: ${rtn}"
@@ -2358,7 +2365,7 @@ For (\$i=0; \$i -le 10; \$i++) {
 
         def hardwareGuid = UUID.randomUUID().toString()
         def networkConfig = opts.networkConfig
-        def scvmmCapabilityProfile = opts.scvmmCapabilityProfile
+        def scvmmCapabilityProfile = opts.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE)
         def scvmmGeneration = opts.scvmmGeneration ?: 'generation1'
         def hardwareProfileName = "Profile${UUID.randomUUID().toString()}"
         def maxCores = opts.maxCores

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
@@ -1995,16 +1995,16 @@ For (\$i=0; \$i -le 10; \$i++) {
         try {
             // When creating an instance, the capability profile is required. When creating a Docker Cluster, there is
             // no capability profile option. We need to check if the field is present before validating it.
-            if (opts.containsKey(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE) && !opts.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE)) {
-                rtn.errors += [field: ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE, msg: 'You must select a capability profile']
+            if (opts.containsKey('scvmmCapabilityProfile') && !opts.scvmmCapabilityProfile) {
+                rtn.errors += [field: 'scvmmCapabilityProfile', msg: 'You must select a capability profile']
             }
             // When creating an instance, the template (i.e. virtual image) is required. When creating a Docker Cluster,
             // there is no user specified virtual image. We need to check if the field is present before validating it.
-            if (opts.containsKey(ScvmmConstants.CFG_TEMPLATE) && !opts.(ScvmmConstants.CFG_TEMPLATE)) {
-                rtn.errors += [field: ScvmmConstants.CFG_TEMPLATE, msg: 'Virtual image is required']
+            if (opts.containsKey('template') && !opts.template) {
+                rtn.errors += [field: 'template', msg: 'Virtual image is required']
             }
             // if(!opts.networkId && opts.networkInterfaces?.size() == 0) {
-            // 	rtn.errors += [field: ScvmmConstants.CFG_NETWORK_INTERFACE, msg: 'You must choose a network']
+            // 	rtn.errors += [field: 'networkInterface', msg: 'You must choose a network']
             // }
             if (opts.networkId) {
                 // great
@@ -2015,29 +2015,29 @@ For (\$i=0; \$i -le 10; \$i++) {
                     def networkId = nic.network?.id ?: nic.network.group
                     log.debug("network.id: ${networkId}")
                     if (!networkId) {
-                        rtn.errors << [field: ScvmmConstants.CFG_NETWORK_INTERFACE, msg: 'Network is required']
+                        rtn.errors << [field: 'networkInterface', msg: 'Network is required']
                     }
                     if (nic.ipMode == 'static' && !nic.ipAddress) {
-                        rtn.errors = [field: ScvmmConstants.CFG_NETWORK_INTERFACE, msg: 'You must enter an ip address']
+                        rtn.errors = [field: 'networkInterface', msg: 'You must enter an ip address']
                     }
                 }
-            } else if (opts?.containsKey(ScvmmConstants.CFG_NETWORK_INTERFACE)) {
+            } else if (opts?.networkInterface) {
                 // UI params
-                log.debug("validateServerConfig networkInterface: ${opts.(ScvmmConstants.CFG_NETWORK_INTERFACE)}")
-                toList(opts?.(ScvmmConstants.CFG_NETWORK_INTERFACE)?.network?.id)?.eachWithIndex { networkId, index ->
+                log.debug("validateServerConfig networkInterface: ${opts.networkInterface}")
+                toList(opts?.networkInterface?.network?.id)?.eachWithIndex { networkId, index ->
                     log.debug("network.id: ${networkId}")
                     if (networkId?.length() < 1) {
-                        rtn.errors << [field: ScvmmConstants.CFG_NETWORK_INTERFACE, msg: 'Network is required']
+                        rtn.errors << [field: 'networkInterface', msg: 'Network is required']
                     }
-                    if (opts.(ScvmmConstants.CFG_NETWORK_INTERFACE)[index].ipMode == 'static' && !opts.(ScvmmConstants.CFG_NETWORK_INTERFACE)[index].ipAddress) {
-                        rtn.errors = [field: ScvmmConstants.CFG_NETWORK_INTERFACE, msg: 'You must enter an ip address']
+                    if (networkInterface[index].ipMode == 'static' && !networkInterface[index].ipAddress) {
+                        rtn.errors = [field: 'networkInterface', msg: 'You must enter an ip address']
                     }
                 }
             } else {
-                rtn.errors << [field: ScvmmConstants.CFG_NETWORK_ID, msg: 'Network is required']
+                rtn.errors << [field: 'networkId', msg: 'Network is required']
             }
-            if (opts.containsKey(ScvmmConstants.CFG_NODE_COUNT) && opts.(ScvmmConstants.CFG_NODE_COUNT) == '') {
-                rtn.errors += [field: ScvmmConstants.CFG_NODE_COUNT, msg: 'You must indicate number of hosts']
+            if (opts.containsKey('nodeCount') && opts.nodeCount == '') {
+                rtn.errors += [field: 'nodeCount', msg: 'You must indicate number of hosts']
             }
             rtn.success = (rtn.errors.size() == 0)
             log.debug "validateServer results: ${rtn}"
@@ -2365,7 +2365,7 @@ For (\$i=0; \$i -le 10; \$i++) {
 
         def hardwareGuid = UUID.randomUUID().toString()
         def networkConfig = opts.networkConfig
-        def scvmmCapabilityProfile = opts.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE)
+        def scvmmCapabilityProfile = opts.scvmmCapabilityProfile
         def scvmmGeneration = opts.scvmmGeneration ?: 'generation1'
         def hardwareProfileName = "Profile${UUID.randomUUID().toString()}"
         def maxCores = opts.maxCores

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
@@ -1994,7 +1994,7 @@ For (\$i=0; \$i -le 10; \$i++) {
         def rtn = [success: false, errors: []]
         try {
             // When creating an instance, the capability profile is required. When creating a Docker Cluster, there is
-            // not capability profile option. We need to check if the field is present before validating it.
+            // no capability profile option. We need to check if the field is present before validating it.
             if (opts.containsKey(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE) && !opts.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE)) {
                 rtn.errors += [field: ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE, msg: 'You must select a capability profile']
             }

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmCloudProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmCloudProvider.groovy
@@ -1,16 +1,7 @@
+// Copyright 2026 Hewlett Packard Enterprise Development LP
+
 package com.morpheusdata.scvmm
 
-import com.morpheusdata.scvmm.helper.morpheus.types.StorageVolumeTypeHelper
-import com.morpheusdata.scvmm.logging.LogInterface
-import com.morpheusdata.scvmm.logging.LogWrapper
-import com.morpheusdata.scvmm.sync.CloudCapabilityProfilesSync
-import com.morpheusdata.scvmm.sync.ClustersSync
-import com.morpheusdata.scvmm.sync.DatastoresSync
-import com.morpheusdata.scvmm.sync.HostSync
-import com.morpheusdata.scvmm.sync.IpPoolsSync
-import com.morpheusdata.scvmm.sync.IsolationNetworkSync
-import com.morpheusdata.scvmm.sync.RegisteredStorageFileSharesSync
-import com.morpheusdata.scvmm.sync.NetworkSync
 import com.morpheusdata.core.MorpheusContext
 import com.morpheusdata.core.Plugin
 import com.morpheusdata.core.data.DataFilter
@@ -20,12 +11,37 @@ import com.morpheusdata.core.providers.CloudProvider
 import com.morpheusdata.core.providers.ProvisionProvider
 import com.morpheusdata.core.util.ConnectionUtils
 import com.morpheusdata.core.util.MorpheusUtils
-import com.morpheusdata.model.*
+import com.morpheusdata.model.BackupProvider
+import com.morpheusdata.model.Cloud
+import com.morpheusdata.model.CloudFolder
+import com.morpheusdata.model.CloudPool
+import com.morpheusdata.model.ComputeServer
+import com.morpheusdata.model.ComputeServerType
+import com.morpheusdata.model.Datastore
+import com.morpheusdata.model.Icon
+import com.morpheusdata.model.Network
+import com.morpheusdata.model.NetworkSubnetType
+import com.morpheusdata.model.NetworkType
+import com.morpheusdata.model.OptionType
+import com.morpheusdata.model.OsType
+import com.morpheusdata.model.PlatformType
+import com.morpheusdata.model.StorageControllerType
+import com.morpheusdata.model.StorageVolumeType
 import com.morpheusdata.request.ValidateCloudRequest
 import com.morpheusdata.response.ServiceResponse
+import com.morpheusdata.scvmm.helper.morpheus.types.StorageVolumeTypeHelper
+import com.morpheusdata.scvmm.logging.LogInterface
+import com.morpheusdata.scvmm.logging.LogWrapper
+import com.morpheusdata.scvmm.sync.CloudCapabilityProfilesSync
+import com.morpheusdata.scvmm.sync.ClustersSync
+import com.morpheusdata.scvmm.sync.DatastoresSync
+import com.morpheusdata.scvmm.sync.HostSync
+import com.morpheusdata.scvmm.sync.IpPoolsSync
+import com.morpheusdata.scvmm.sync.IsolationNetworkSync
+import com.morpheusdata.scvmm.sync.NetworkSync
+import com.morpheusdata.scvmm.sync.RegisteredStorageFileSharesSync
 import com.morpheusdata.scvmm.sync.TemplatesSync
 import com.morpheusdata.scvmm.sync.VirtualMachineSync
-import groovy.util.logging.Slf4j
 
 class ScvmmCloudProvider implements CloudProvider {
 	public static final String CLOUD_PROVIDER_CODE = 'scvmm'
@@ -368,9 +384,9 @@ class ScvmmCloudProvider implements CloudProvider {
 
 		// Host option type is used by multiple compute server types.
 		OptionType hostOptionType = new OptionType(code:'computeServerType.scvmm.capabilityProfile', inputType: OptionType.InputType.SELECT,
-				name:'capability profile', category:'provisionType.scvmm', optionSourceType:'scvmm', fieldName:'scvmmCapabilityProfile',
+				name: 'capability profile', category: 'provisionType.scvmm', optionSourceType: 'scvmm', fieldName: ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE,
 				fieldCode: 'gomorpheus.optiontype.CapabilityProfile', fieldLabel:'Capability Profile', fieldContext:'config', fieldGroup:'Options',
-				required:true, enabled:true, optionSource:'scvmmCapabilityProfile', editable:true, global:false, placeHolder:null, helpBlock:'',
+				required: true, enabled: true, optionSource: ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE, editable: true, global: false, placeHolder: null, helpBlock: '',
 				defaultValue:null, custom:false, displayOrder:10, fieldClass:null
 		)
 

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmCloudProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmCloudProvider.groovy
@@ -2,33 +2,6 @@
 
 package com.morpheusdata.scvmm
 
-import com.morpheusdata.core.MorpheusContext
-import com.morpheusdata.core.Plugin
-import com.morpheusdata.core.data.DataFilter
-import com.morpheusdata.core.data.DataOrFilter
-import com.morpheusdata.core.data.DataQuery
-import com.morpheusdata.core.providers.CloudProvider
-import com.morpheusdata.core.providers.ProvisionProvider
-import com.morpheusdata.core.util.ConnectionUtils
-import com.morpheusdata.core.util.MorpheusUtils
-import com.morpheusdata.model.BackupProvider
-import com.morpheusdata.model.Cloud
-import com.morpheusdata.model.CloudFolder
-import com.morpheusdata.model.CloudPool
-import com.morpheusdata.model.ComputeServer
-import com.morpheusdata.model.ComputeServerType
-import com.morpheusdata.model.Datastore
-import com.morpheusdata.model.Icon
-import com.morpheusdata.model.Network
-import com.morpheusdata.model.NetworkSubnetType
-import com.morpheusdata.model.NetworkType
-import com.morpheusdata.model.OptionType
-import com.morpheusdata.model.OsType
-import com.morpheusdata.model.PlatformType
-import com.morpheusdata.model.StorageControllerType
-import com.morpheusdata.model.StorageVolumeType
-import com.morpheusdata.request.ValidateCloudRequest
-import com.morpheusdata.response.ServiceResponse
 import com.morpheusdata.scvmm.helper.morpheus.types.StorageVolumeTypeHelper
 import com.morpheusdata.scvmm.logging.LogInterface
 import com.morpheusdata.scvmm.logging.LogWrapper
@@ -38,10 +11,23 @@ import com.morpheusdata.scvmm.sync.DatastoresSync
 import com.morpheusdata.scvmm.sync.HostSync
 import com.morpheusdata.scvmm.sync.IpPoolsSync
 import com.morpheusdata.scvmm.sync.IsolationNetworkSync
-import com.morpheusdata.scvmm.sync.NetworkSync
 import com.morpheusdata.scvmm.sync.RegisteredStorageFileSharesSync
+import com.morpheusdata.scvmm.sync.NetworkSync
+import com.morpheusdata.core.MorpheusContext
+import com.morpheusdata.core.Plugin
+import com.morpheusdata.core.data.DataFilter
+import com.morpheusdata.core.data.DataOrFilter
+import com.morpheusdata.core.data.DataQuery
+import com.morpheusdata.core.providers.CloudProvider
+import com.morpheusdata.core.providers.ProvisionProvider
+import com.morpheusdata.core.util.ConnectionUtils
+import com.morpheusdata.core.util.MorpheusUtils
+import com.morpheusdata.model.*
+import com.morpheusdata.request.ValidateCloudRequest
+import com.morpheusdata.response.ServiceResponse
 import com.morpheusdata.scvmm.sync.TemplatesSync
 import com.morpheusdata.scvmm.sync.VirtualMachineSync
+import groovy.util.logging.Slf4j
 
 class ScvmmCloudProvider implements CloudProvider {
 	public static final String CLOUD_PROVIDER_CODE = 'scvmm'
@@ -384,9 +370,9 @@ class ScvmmCloudProvider implements CloudProvider {
 
 		// Host option type is used by multiple compute server types.
 		OptionType hostOptionType = new OptionType(code:'computeServerType.scvmm.capabilityProfile', inputType: OptionType.InputType.SELECT,
-				name: 'capability profile', category: 'provisionType.scvmm', optionSourceType: 'scvmm', fieldName: ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE,
+				name:'capability profile', category:'provisionType.scvmm', optionSourceType:'scvmm', fieldName:'scvmmCapabilityProfile',
 				fieldCode: 'gomorpheus.optiontype.CapabilityProfile', fieldLabel:'Capability Profile', fieldContext:'config', fieldGroup:'Options',
-				required: true, enabled: true, optionSource: ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE, editable: true, global: false, placeHolder: null, helpBlock: '',
+				required:true, enabled:true, optionSource:'scvmmCapabilityProfile', editable:true, global:false, placeHolder:null, helpBlock:'',
 				defaultValue:null, custom:false, displayOrder:10, fieldClass:null
 		)
 
@@ -441,6 +427,15 @@ class ScvmmCloudProvider implements CloudProvider {
 				creatable:false, computeService:'scvmmComputeService', displayOrder: 6, hasAutomation:true, reconfigureSupported:true, guestVm:true,
 				containerHypervisor:true, bareMetalHost:false, vmHypervisor:false, agentType:ComputeServerType.AgentType.node, containerEngine:'docker',
 				provisionTypeCode:'scvmm', computeTypeCode:'docker-host', optionTypes:[hostOptionType]
+		)
+
+		//mvm
+		serverTypes << new ComputeServerType(code: 'mvmDockerHost', name: 'MVM Docker Host', description: '', platform: PlatformType.linux, nodeType: 'morpheus-node',
+				enabled: true, selectable: false, externalDelete: true, managed: true, controlPower: true, controlSuspend: true, creatable: false, computeService: 'kvmComputeService',
+				displayOrder: 17, hasAutomation: true,
+				containerHypervisor: true, bareMetalHost: false, hasDevices: true, supportsDeviceAttachment: true, vmHypervisor: false, agentType: ComputeServerType.AgentType.node, containerEngine: 'docker',
+				provisionTypeCode: 'mvm', computeTypeCode: 'docker-host',
+				reconfigureSupported: false, guestVm: false, hasMaintenanceMode: false,
 		)
 
 		return serverTypes

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmConstants.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmConstants.groovy
@@ -8,6 +8,19 @@ import java.util.regex.Pattern
 
 @CompileStatic
 class ScvmmConstants {
+
+    // -------------------------------------------------------------------------
+    // Config / option-source map key constants.
+    // These strings are used as map keys, fieldNames, and optionSource references
+    // across multiple providers and services. Centralized here to prevent typos
+    // and make rename-refactors a one-line change.
+    // -------------------------------------------------------------------------
+    static final String CFG_SCVMM_CAPABILITY_PROFILE = 'scvmmCapabilityProfile'
+    static final String CFG_NETWORK_INTERFACE = 'networkInterface'
+    static final String CFG_NETWORK_ID = 'networkId'
+    static final String CFG_NODE_COUNT = 'nodeCount'
+    static final String CFG_TEMPLATE = 'template'
+
     /**
      * SCVMM can create temporary VM templates with names like "Temporary Template{UUID}" while the SCVMM plugin can
      * create temporary VM templates with names like "Temporary Morpheus Template{UUID}". These occur during

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmConstants.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmConstants.groovy
@@ -8,19 +8,6 @@ import java.util.regex.Pattern
 
 @CompileStatic
 class ScvmmConstants {
-
-    // -------------------------------------------------------------------------
-    // Config / option-source map key constants.
-    // These strings are used as map keys, fieldNames, and optionSource references
-    // across multiple providers and services. Centralized here to prevent typos
-    // and make rename-refactors a one-line change.
-    // -------------------------------------------------------------------------
-    static final String CFG_SCVMM_CAPABILITY_PROFILE = 'scvmmCapabilityProfile'
-    static final String CFG_NETWORK_INTERFACE = 'networkInterface'
-    static final String CFG_NETWORK_ID = 'networkId'
-    static final String CFG_NODE_COUNT = 'nodeCount'
-    static final String CFG_TEMPLATE = 'template'
-
     /**
      * SCVMM can create temporary VM templates with names like "Temporary Template{UUID}" while the SCVMM plugin can
      * create temporary VM templates with names like "Temporary Morpheus Template{UUID}". These occur during

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
@@ -1,3 +1,5 @@
+// Copyright 2026 Hewlett Packard Enterprise Development LP
+
 package com.morpheusdata.scvmm
 
 import com.morpheusdata.PrepareHostResponse
@@ -12,7 +14,29 @@ import com.morpheusdata.core.providers.HostProvisionProvider
 import com.morpheusdata.core.providers.ProvisionProvider
 import com.morpheusdata.core.providers.WorkloadProvisionProvider
 import com.morpheusdata.core.util.ComputeUtility
-import com.morpheusdata.model.*
+import com.morpheusdata.model.Cloud
+import com.morpheusdata.model.ComputeCapacityInfo
+import com.morpheusdata.model.ComputeServer
+import com.morpheusdata.model.ComputeServerInterface
+import com.morpheusdata.model.ComputeServerType
+import com.morpheusdata.model.ComputeTypeSet
+import com.morpheusdata.model.Datastore
+import com.morpheusdata.model.HostType
+import com.morpheusdata.model.Icon
+import com.morpheusdata.model.Instance
+import com.morpheusdata.model.NetAddress
+import com.morpheusdata.model.OptionType
+import com.morpheusdata.model.OsType
+import com.morpheusdata.model.PlatformType
+import com.morpheusdata.model.ProcessEvent
+import com.morpheusdata.model.ResourcePermission
+import com.morpheusdata.model.ServicePlan
+import com.morpheusdata.model.StorageVolume
+import com.morpheusdata.model.StorageVolumeType
+import com.morpheusdata.model.VirtualImage
+import com.morpheusdata.model.VirtualImageLocation
+import com.morpheusdata.model.Workload
+import com.morpheusdata.model.WorkloadType
 import com.morpheusdata.model.provisioning.HostRequest
 import com.morpheusdata.model.provisioning.WorkloadRequest
 import com.morpheusdata.request.ResizeRequest
@@ -170,7 +194,7 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
                 code: 'provisionType.scvmm.capabilityProfile',
                 category: 'provisionType.scvmm',
                 inputType: OptionType.InputType.SELECT,
-                fieldName: 'scvmmCapabilityProfile',
+                fieldName: ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE,
                 fieldContext: 'config',
                 fieldCode: 'gomorpheus.optiontype.CapabilityProfile',
                 fieldLabel: 'Capability Profile',
@@ -183,7 +207,7 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
                 defaultValue: null,
                 custom: false,
                 fieldClass: null,
-                optionSource: 'scvmmCapabilityProfile',
+                optionSource: ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE,
                 optionSourceType: 'scvmm'
         )
 
@@ -518,7 +542,21 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
      */
     @Override
     ServiceResponse validateWorkload(Map opts) {
-        return ServiceResponse.success()
+        log.debug "validateWorkload: ${opts}"
+        def rtn = ServiceResponse.success()
+        try {
+            Map validationOpts = getValidateServerConfigOptions(opts)
+            def validationResults = apiService.validateServerConfig(validationOpts)
+            if (!validationResults.success) {
+                rtn.success = false
+                validationResults.errors.each { error ->
+                    rtn.errors[error.field as String] = error.msg as String
+                }
+            }
+        } catch (e) {
+            log.error("error in validateWorkload: ${e.message}", e)
+        }
+        return rtn
     }
 
     /**
@@ -620,10 +658,10 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
             }
 
             scvmmOpts += apiService.getScvmmControllerOpts(cloud, controllerNode)
-            if (containerConfig.template || virtualImage?.id) {
-				if(containerConfig.template) {
-					virtualImage = context.services.virtualImage.get(containerConfig.template?.toLong())
-				}
+            if (containerConfig.(ScvmmConstants.CFG_TEMPLATE) || virtualImage?.id) {
+                if (containerConfig.(ScvmmConstants.CFG_TEMPLATE)) {
+                    virtualImage = context.services.virtualImage.get(containerConfig.(ScvmmConstants.CFG_TEMPLATE)?.toLong())
+                }
 
                 scvmmOpts.scvmmGeneration = virtualImage?.getConfigProperty('generation') ?: 'generation1'
                 scvmmOpts.isSyncdImage = virtualImage?.refType == 'ComputeZone'
@@ -1178,7 +1216,10 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
                 network               : network, networkId: network?.id, platform: platform, externalId: container.server.externalId, networkType: containerConfig.networkType,
                 containerConfig       : containerConfig, resourcePool: resourcePool?.externalId, hostId: containerConfig.hostId,
                 osDiskSize            : maxStorage, maxTotalStorage: maxTotalStorage, dataDisks: dataDisks,
-                scvmmCapabilityProfile: (containerConfig.scvmmCapabilityProfile?.toString() != '-1' ? containerConfig.scvmmCapabilityProfile : null),
+                (ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE): (
+                        containerConfig.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE)?.toString() != '-1' ?
+                                containerConfig.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE) : null
+                ),
                 accountId             : container.account?.id
         ]
     }
@@ -1406,7 +1447,11 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
         def serverFolder = "morpheus\\morpheus_server_${server.id}"
         return [name     : serverName, vmId: server.externalId, config: serverConfig, server: server, serverId: server.id, memory: maxMemory, osDiskSize: maxStorage, externalId: server.externalId, maxCpu: maxCpu,
                 maxCores : maxCores, serverFolder: serverFolder, hostname: server.getExternalHostname(), network: network, networkId: network?.id, maxTotalStorage: maxTotalStorage,
-                dataDisks: dataDisks, scvmmCapabilityProfile: serverConfig.scvmmCapabilityProfile?.toString() != '-1' ? serverConfig.scvmmCapabilityProfile : null,
+                dataDisks                                    : dataDisks,
+                (ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE): (
+                        serverConfig.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE)?.toString() != '-1' ?
+                                serverConfig.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE) : null
+                ),
                 accountId: server.account?.id]
     }
 
@@ -1605,15 +1650,13 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
             if (server.computeServerType?.vmHypervisor == true) {
                 rtn = ServiceResponse.success()
             } else {
-                def validationOpts = [
-                        networkId             : opts?.networkInterface?.network?.id ?: opts?.config?.networkInterface?.network?.id ?: opts.networkInterfaces.getAt(0)?.network?.id,
-                        scvmmCapabilityProfile: opts?.config?.scvmmCapabilityProfile ?: opts?.scvmmCapabilityProfile,
-                        nodeCount             : opts?.config?.nodeCount
-                ]
+                Map validationOpts = getValidateServerConfigOptions(opts)
                 def validationResults = apiService.validateServerConfig(validationOpts)
                 if (!validationResults.success) {
                     rtn.success = false
-                    rtn.errors += validationResults.errors
+                    validationResults.errors.each { error ->
+                        rtn.errors[error.field as String] = error.msg as String
+                    }
                 }
             }
         } catch (e) {
@@ -1621,6 +1664,46 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
         }
         return rtn
     }
+
+    /**
+     * Builds the options map for validating the server config. This is used in both validateHost and runWorkload,
+     * so we want to make sure we are checking all possible locations for these values (top level opts, opts.config,
+     * and nested config for network interfaces).
+     * @param opts the options map that may contain various configurations for the server and network interfaces
+     * @return a map of options to be used for validating the server config, including networkId, capability profile,
+     *         node count, and template if available
+     */
+    static protected Map getValidateServerConfigOptions(Map opts = [:]) {
+        // Build the options map for validating the server config. This is used in both validateHost and runWorkload,
+        // so we want to make sure we are checking all possible locations for these values (top level opts, opts.config,
+        // and nested config for network interfaces).
+        Map validationOpts = [
+                networkId: opts?.(ScvmmConstants.CFG_NETWORK_INTERFACE)?.network?.id ?:
+                        opts?.config?.(ScvmmConstants.CFG_NETWORK_INTERFACE)?.network?.id ?:
+                                opts.networkInterfaces.getAt(0)?.network?.id,
+        ]
+
+        // Check all possible locations for optional capability profile
+        if (opts?.config?.containsKey(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE)) {
+            validationOpts.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE) =
+                    opts.config.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE)
+        } else if (opts?.containsKey(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE)) {
+            validationOpts.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE) = opts.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE)
+        }
+
+        // Check all possible locations for optional node count (for validating cluster configs)
+        if (opts?.config?.containsKey(ScvmmConstants.CFG_NODE_COUNT)) {
+            validationOpts.(ScvmmConstants.CFG_NODE_COUNT) = opts.config.(ScvmmConstants.CFG_NODE_COUNT)
+        }
+
+        // Check all possible locations for optional template (for validating virtual image configs)
+        if (opts?.config?.containsKey(ScvmmConstants.CFG_TEMPLATE)) {
+            validationOpts.(ScvmmConstants.CFG_TEMPLATE) = opts.config.(ScvmmConstants.CFG_TEMPLATE)
+        }
+
+        return validationOpts
+    }
+
 
     protected ComputeServer saveAndGet(ComputeServer server) {
         def saveResult = context.async.computeServer.bulkSave([server]).blockingGet()
@@ -1896,8 +1979,8 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
             if (layout && typeSet) {
                 virtualImage = typeSet.workloadType.virtualImage
                 imageId = virtualImage.externalId
-            } else if (imageType == 'custom' && config.template) {
-                def virtualImageId = config.template?.toLong()
+            } else if (imageType == 'custom' && config.(ScvmmConstants.CFG_TEMPLATE)) {
+                def virtualImageId = config.(ScvmmConstants.CFG_TEMPLATE)?.toLong()
                 virtualImage = context.services.virtualImage.get(virtualImageId)
                 imageId = virtualImage.externalId
             } else {

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
@@ -14,29 +14,7 @@ import com.morpheusdata.core.providers.HostProvisionProvider
 import com.morpheusdata.core.providers.ProvisionProvider
 import com.morpheusdata.core.providers.WorkloadProvisionProvider
 import com.morpheusdata.core.util.ComputeUtility
-import com.morpheusdata.model.Cloud
-import com.morpheusdata.model.ComputeCapacityInfo
-import com.morpheusdata.model.ComputeServer
-import com.morpheusdata.model.ComputeServerInterface
-import com.morpheusdata.model.ComputeServerType
-import com.morpheusdata.model.ComputeTypeSet
-import com.morpheusdata.model.Datastore
-import com.morpheusdata.model.HostType
-import com.morpheusdata.model.Icon
-import com.morpheusdata.model.Instance
-import com.morpheusdata.model.NetAddress
-import com.morpheusdata.model.OptionType
-import com.morpheusdata.model.OsType
-import com.morpheusdata.model.PlatformType
-import com.morpheusdata.model.ProcessEvent
-import com.morpheusdata.model.ResourcePermission
-import com.morpheusdata.model.ServicePlan
-import com.morpheusdata.model.StorageVolume
-import com.morpheusdata.model.StorageVolumeType
-import com.morpheusdata.model.VirtualImage
-import com.morpheusdata.model.VirtualImageLocation
-import com.morpheusdata.model.Workload
-import com.morpheusdata.model.WorkloadType
+import com.morpheusdata.model.*
 import com.morpheusdata.model.provisioning.HostRequest
 import com.morpheusdata.model.provisioning.WorkloadRequest
 import com.morpheusdata.request.ResizeRequest
@@ -194,7 +172,7 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
                 code: 'provisionType.scvmm.capabilityProfile',
                 category: 'provisionType.scvmm',
                 inputType: OptionType.InputType.SELECT,
-                fieldName: ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE,
+                fieldName: 'scvmmCapabilityProfile',
                 fieldContext: 'config',
                 fieldCode: 'gomorpheus.optiontype.CapabilityProfile',
                 fieldLabel: 'Capability Profile',
@@ -207,7 +185,7 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
                 defaultValue: null,
                 custom: false,
                 fieldClass: null,
-                optionSource: ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE,
+                optionSource: 'scvmmCapabilityProfile',
                 optionSourceType: 'scvmm'
         )
 
@@ -545,7 +523,7 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
         log.debug "validateWorkload: ${opts}"
         def rtn = ServiceResponse.success()
         try {
-            Map validationOpts = getValidateServerConfigOptions(opts)
+            def validationOpts = getValidateServerConfigOptions(opts)
             def validationResults = apiService.validateServerConfig(validationOpts)
             if (!validationResults.success) {
                 rtn.success = false
@@ -658,10 +636,10 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
             }
 
             scvmmOpts += apiService.getScvmmControllerOpts(cloud, controllerNode)
-            if (containerConfig.(ScvmmConstants.CFG_TEMPLATE) || virtualImage?.id) {
-                if (containerConfig.(ScvmmConstants.CFG_TEMPLATE)) {
-                    virtualImage = context.services.virtualImage.get(containerConfig.(ScvmmConstants.CFG_TEMPLATE)?.toLong())
-                }
+            if (containerConfig.template || virtualImage?.id) {
+				if(containerConfig.template) {
+					virtualImage = context.services.virtualImage.get(containerConfig.template?.toLong())
+				}
 
                 scvmmOpts.scvmmGeneration = virtualImage?.getConfigProperty('generation') ?: 'generation1'
                 scvmmOpts.isSyncdImage = virtualImage?.refType == 'ComputeZone'
@@ -1216,10 +1194,7 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
                 network               : network, networkId: network?.id, platform: platform, externalId: container.server.externalId, networkType: containerConfig.networkType,
                 containerConfig       : containerConfig, resourcePool: resourcePool?.externalId, hostId: containerConfig.hostId,
                 osDiskSize            : maxStorage, maxTotalStorage: maxTotalStorage, dataDisks: dataDisks,
-                (ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE): (
-                        containerConfig.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE)?.toString() != '-1' ?
-                                containerConfig.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE) : null
-                ),
+                scvmmCapabilityProfile: (containerConfig.scvmmCapabilityProfile?.toString() != '-1' ? containerConfig.scvmmCapabilityProfile : null),
                 accountId             : container.account?.id
         ]
     }
@@ -1447,11 +1422,7 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
         def serverFolder = "morpheus\\morpheus_server_${server.id}"
         return [name     : serverName, vmId: server.externalId, config: serverConfig, server: server, serverId: server.id, memory: maxMemory, osDiskSize: maxStorage, externalId: server.externalId, maxCpu: maxCpu,
                 maxCores : maxCores, serverFolder: serverFolder, hostname: server.getExternalHostname(), network: network, networkId: network?.id, maxTotalStorage: maxTotalStorage,
-                dataDisks                                    : dataDisks,
-                (ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE): (
-                        serverConfig.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE)?.toString() != '-1' ?
-                                serverConfig.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE) : null
-                ),
+                dataDisks: dataDisks, scvmmCapabilityProfile: serverConfig.scvmmCapabilityProfile?.toString() != '-1' ? serverConfig.scvmmCapabilityProfile : null,
                 accountId: server.account?.id]
     }
 
@@ -1650,7 +1621,7 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
             if (server.computeServerType?.vmHypervisor == true) {
                 rtn = ServiceResponse.success()
             } else {
-                Map validationOpts = getValidateServerConfigOptions(opts)
+                def validationOpts = getValidateServerConfigOptions(opts)
                 def validationResults = apiService.validateServerConfig(validationOpts)
                 if (!validationResults.success) {
                     rtn.success = false
@@ -1674,31 +1645,30 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
      *         node count, and template if available
      */
     static protected Map getValidateServerConfigOptions(Map opts = [:]) {
-        // Build the options map for validating the server config. This is used in both validateHost and runWorkload,
-        // so we want to make sure we are checking all possible locations for these values (top level opts, opts.config,
-        // and nested config for network interfaces).
+        // Build the options map for validating the server config. This is used in both validateHost and
+        // validateWorkload,  so we want to make sure we are checking all possible locations for these
+        // values (top level opts, opts.config, and nested config for network interfaces).
         Map validationOpts = [
-                networkId: opts?.(ScvmmConstants.CFG_NETWORK_INTERFACE)?.network?.id ?:
-                        opts?.config?.(ScvmmConstants.CFG_NETWORK_INTERFACE)?.network?.id ?:
+                networkId: opts?.networkInterface?.network?.id ?:
+                        opts?.config?.networkInterface?.network?.id ?:
                                 opts.networkInterfaces.getAt(0)?.network?.id,
         ]
 
         // Check all possible locations for optional capability profile
-        if (opts?.config?.containsKey(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE)) {
-            validationOpts.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE) =
-                    opts.config.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE)
-        } else if (opts?.containsKey(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE)) {
-            validationOpts.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE) = opts.(ScvmmConstants.CFG_SCVMM_CAPABILITY_PROFILE)
+        if (opts?.config?.containsKey('scvmmCapabilityProfile')) {
+            validationOpts.scvmmCapabilityProfile = opts.config.scvmmCapabilityProfile
+        } else if (opts?.containsKey('scvmmCapabilityProfile')) {
+            validationOpts.scvmmCapabilityProfile = opts.scvmmCapabilityProfile
         }
 
         // Check all possible locations for optional node count (for validating cluster configs)
-        if (opts?.config?.containsKey(ScvmmConstants.CFG_NODE_COUNT)) {
-            validationOpts.(ScvmmConstants.CFG_NODE_COUNT) = opts.config.(ScvmmConstants.CFG_NODE_COUNT)
+        if (opts?.config?.containsKey('nodeCount')) {
+            validationOpts.nodeCount = opts.config.nodeCount
         }
 
         // Check all possible locations for optional template (for validating virtual image configs)
-        if (opts?.config?.containsKey(ScvmmConstants.CFG_TEMPLATE)) {
-            validationOpts.(ScvmmConstants.CFG_TEMPLATE) = opts.config.(ScvmmConstants.CFG_TEMPLATE)
+        if (opts?.config?.containsKey('template')) {
+            validationOpts.template = opts.config.template
         }
 
         return validationOpts
@@ -1979,8 +1949,8 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
             if (layout && typeSet) {
                 virtualImage = typeSet.workloadType.virtualImage
                 imageId = virtualImage.externalId
-            } else if (imageType == 'custom' && config.(ScvmmConstants.CFG_TEMPLATE)) {
-                def virtualImageId = config.(ScvmmConstants.CFG_TEMPLATE)?.toLong()
+            } else if (imageType == 'custom' && config.template) {
+                def virtualImageId = config.template?.toLong()
                 virtualImage = context.services.virtualImage.get(virtualImageId)
                 imageId = virtualImage.externalId
             } else {

--- a/src/main/resources/scribe/scvmm-compute-types.scribe
+++ b/src/main/resources/scribe/scvmm-compute-types.scribe
@@ -96,6 +96,21 @@ resource "compute-type-set" "docker-scvmm-ubuntu-22_04-set" {
   installStorageRuntime   = true
 }
 
+resource "compute-type-set" "docker_ubuntu_22_04_mvm_amd64_set" {
+  code                    = "docker-ubuntu-22.04-mvm-amd64-set"
+  name                    = "Morpheus MVM Docker Host"
+  workloadType            = "docker-ubuntu-22.04-mvm-amd64"
+  computeServerType       = "mvmDockerHost"
+  category                = "ubuntu"
+  priorityOrder           = 0
+  dynamicCount            = true
+  nodeCount               = 1
+  nodeType                = "worker"
+  canAddNodes             = true
+  installContainerRuntime = true
+  installStorageRuntime   = true
+}
+
 resource "compute-type-layout" "docker-scvmm-ubuntu-22_04-single" {
   code              = "docker-scvmm-ubuntu-22.04-single"
   name              = "SCVMM Docker Host"
@@ -111,6 +126,23 @@ resource "compute-type-layout" "docker-scvmm-ubuntu-22_04-single" {
     compute-type-set.docker-scvmm-ubuntu-22_04-set
   ]
   provisionType = "scvmm"
+}
+
+resource "compute-type-layout" "docker-ubuntu-22.04-mvm-amd64-single" {
+  code              = "docker-ubuntu-22.04-mvm-amd64-single"
+  name              = "Docker on MVM"
+  sortOrder         = 4
+  computeVersion    = "22.04"
+  description       = "This will provision a single Ubuntu 22.04 docker host vm in MVM"
+  type              = "mvmDockerHost"
+  serverCount       = 1
+  memoryRequirement = 1024 * 1024 * 1024
+  hasAutoScale      = false
+  groupType         = "docker-cluster"
+  computeServers    = [
+    compute-type-set.docker-ubuntu-22.04-mvm-amd64-set
+  ]
+  provisionType     = "kvm"
 }
 
 resource "compute-type-set" "kubernetes-scvmm-ha-master-ubuntu-16_04-set" {

--- a/src/main/resources/scribe/scvmm-instance-type.scribe
+++ b/src/main/resources/scribe/scvmm-instance-type.scribe
@@ -10,7 +10,7 @@ resource "option-type" "provisionType-scvmm-virtual-image" {
   fieldLabel   = "Virtual Image"
   fieldContext = "config"
   fieldGroup   = "SCVMM Options"
-  required     = false
+  required     = true
   enabled      = true
   editable     = true
   global       = false


### PR DESCRIPTION
This PR incorporates several enhancements to improve user input validation:

1. The `validateServerConfig` method was updated to support requiring a virtual image is the option is presented to the user
2. The `ScvmmProvisionProvider` `validateWorkload` was populate to ensure the user entered the required properties before letting them provision an instance
3. The `validateHost` method was updated to correctly map the validation results into the return `ServiceResponse`

In addition, if the user chooses to create an SCVMM Docker Cluster, support was added so that the `validateHost` capability of the plugin would be called:

1. The `ScvmmCloudProvider` `getComputeServerTypes()` added a new `mvmDockerHost` coded entry so our plugin would be engaged to validate the host settings.
2. The `scvmm-compute-types.scribe` was updated to define the compute server type for the Docker Cluster VM.