### PR TITLE
MORPH-8189: Add SCVMM validateWorkload and validateHost support

### DIFF
--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
@@ -1993,8 +1993,15 @@ For (\$i=0; \$i -le 10; \$i++) {
         log.debug("validateServerConfig: ${opts}")
         def rtn = [success: false, errors: []]
         try {
-            if (!opts.scvmmCapabilityProfile) {
+            // When creating an instance, the capability profile is required. When creating a Docker Cluster, there is
+            // no capability profile option. We need to check if the field is present before validating it.
+            if (opts.containsKey('scvmmCapabilityProfile') && !opts.scvmmCapabilityProfile) {
                 rtn.errors += [field: 'scvmmCapabilityProfile', msg: 'You must select a capability profile']
+            }
+            // When creating an instance, the template (i.e. virtual image) is required. When creating a Docker Cluster,
+            // there is no user specified virtual image. We need to check if the field is present before validating it.
+            if (opts.containsKey('template') && !opts.template) {
+                rtn.errors += [field: 'template', msg: 'Virtual image is required']
             }
             // if(!opts.networkId && opts.networkInterfaces?.size() == 0) {
             // 	rtn.errors += [field: 'networkInterface', msg: 'You must choose a network']

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
@@ -2033,7 +2033,7 @@ For (\$i=0; \$i -le 10; \$i++) {
                     }
                 }
             } else {
-                rtn.errors << [field: 'networkInterface.network.id', msg: 'Network is required']
+                rtn.errors << [field: 'networkId', msg: 'Network is required']
             }
             if (opts.containsKey('nodeCount') && opts.nodeCount == '') {
                 rtn.errors += [field: 'nodeCount', msg: 'You must indicate number of hosts']

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
@@ -1993,13 +1993,9 @@ For (\$i=0; \$i -le 10; \$i++) {
         log.debug("validateServerConfig: ${opts}")
         def rtn = [success: false, errors: []]
         try {
-            // When creating an instance, the capability profile is required. When creating a Docker Cluster, there is
-            // no capability profile option. We need to check if the field is present before validating it.
             if (opts.containsKey('scvmmCapabilityProfile') && !opts.scvmmCapabilityProfile) {
                 rtn.errors += [field: 'scvmmCapabilityProfile', msg: 'You must select a capability profile']
             }
-            // When creating an instance, the template (i.e. virtual image) is required. When creating a Docker Cluster,
-            // there is no user specified virtual image. We need to check if the field is present before validating it.
             if (opts.containsKey('template') && !opts.template) {
                 rtn.errors += [field: 'template', msg: 'Virtual image is required']
             }

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
@@ -2030,7 +2030,7 @@ For (\$i=0; \$i -le 10; \$i++) {
                     }
                 }
             } else {
-                rtn.errors << [field: 'networkId', msg: 'Network is required']
+                rtn.errors << [field: 'networkInterface.network.id', msg: 'Network is required']
             }
             if (opts.containsKey('nodeCount') && opts.nodeCount == '') {
                 rtn.errors += [field: 'nodeCount', msg: 'You must indicate number of hosts']

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
@@ -1,3 +1,5 @@
+// Copyright 2026 Hewlett Packard Enterprise Development LP
+
 package com.morpheusdata.scvmm
 
 import com.morpheusdata.PrepareHostResponse
@@ -518,7 +520,7 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
      */
     @Override
     ServiceResponse validateWorkload(Map opts) {
-        return ServiceResponse.success()
+        return validateServerConfigOptions(opts)
     }
 
     /**
@@ -1600,20 +1602,22 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
     @Override
     ServiceResponse validateHost(ComputeServer server, Map opts = [:]) {
         log.debug("validateHostConfiguration:$opts")
+        if (server?.computeServerType?.vmHypervisor == true) {
+            return ServiceResponse.success()
+        }
+        return validateServerConfigOptions(opts)
+    }
+
+    protected ServiceResponse validateServerConfigOptions(Map opts = [:]) {
         def rtn = ServiceResponse.success()
         try {
-            if (server.computeServerType?.vmHypervisor == true) {
-                rtn = ServiceResponse.success()
-            } else {
-                def validationOpts = [
-                        networkId             : opts?.networkInterface?.network?.id ?: opts?.config?.networkInterface?.network?.id ?: opts.networkInterfaces.getAt(0)?.network?.id,
-                        scvmmCapabilityProfile: opts?.config?.scvmmCapabilityProfile ?: opts?.scvmmCapabilityProfile,
-                        nodeCount             : opts?.config?.nodeCount
-                ]
-                def validationResults = apiService.validateServerConfig(validationOpts)
-                if (!validationResults.success) {
-                    rtn.success = false
-                    rtn.errors += validationResults.errors
+            def validationOpts = getValidateServerConfigOptions(opts)
+            def validationResults = apiService.validateServerConfig(validationOpts)
+            if (!validationResults.success) {
+                log.error("Server config validation failed: ${validationResults.errors}")
+                rtn.success = false
+                validationResults.errors.each { error ->
+                    rtn.errors[error.field as String] = error.msg as String
                 }
             }
         } catch (e) {
@@ -1621,6 +1625,45 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
         }
         return rtn
     }
+
+    /**
+     * Builds the options map for validating the server config. This is used in both validateHost and runWorkload,
+     * so we want to make sure we are checking all possible locations for these values (top level opts, opts.config,
+     * and nested config for network interfaces).
+     * @param opts the options map that may contain various configurations for the server and network interfaces
+     * @return a map of options to be used for validating the server config, including networkId, capability profile,
+     *         node count, and template if available
+     */
+    static protected Map getValidateServerConfigOptions(Map opts = [:]) {
+        // Build the options map for validating the server config. This is used in both validateHost and
+        // validateWorkload,  so we want to make sure we are checking all possible locations for these
+        // values (top level opts, opts.config, and nested config for network interfaces).
+        Map validationOpts = [
+                networkId: opts?.networkInterface?.network?.id ?:
+                        opts?.config?.networkInterface?.network?.id ?:
+                                opts.networkInterfaces.getAt(0)?.network?.id,
+        ]
+
+        // Check all possible locations for optional capability profile
+        if (opts?.config?.containsKey('scvmmCapabilityProfile')) {
+            validationOpts.scvmmCapabilityProfile = opts.config.scvmmCapabilityProfile
+        } else if (opts?.containsKey('scvmmCapabilityProfile')) {
+            validationOpts.scvmmCapabilityProfile = opts.scvmmCapabilityProfile
+        }
+
+        // Check all possible locations for optional node count (for validating cluster configs)
+        if (opts?.config?.containsKey('nodeCount')) {
+            validationOpts.nodeCount = opts.config.nodeCount
+        }
+
+        // Check all possible locations for optional template (for validating virtual image configs)
+        if (opts?.config?.containsKey('template')) {
+            validationOpts.template = opts.config.template
+        }
+
+        return validationOpts
+    }
+
 
     protected ComputeServer saveAndGet(ComputeServer server) {
         def saveResult = context.async.computeServer.bulkSave([server]).blockingGet()

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
@@ -1619,10 +1619,12 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
             def validationResults = apiService.validateServerConfig(validationOpts)
             if (!validationResults.success) {
                 log.error("Server config validation failed: ${validationResults.errors}")
-                rtn.success = false
-                validationResults.errors.each { error ->
-                    rtn.errors[error.field as String] = error.msg as String
+                (validationResults.errors ?: []).each { error ->
+                    def field = error?.field?.toString() ?: 'general'
+                    def msg = error?.msg?.toString() ?: 'Validation failed'
+                    rtn.errors[field] = msg
                 }
+                rtn.success = false
             }
         } catch (e) {
             log.error("error in validateHost:${e.message}", e)
@@ -1643,7 +1645,7 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
         Map validationOpts = [
                 networkId: opts?.networkInterface?.network?.id ?:
                         opts?.config?.networkInterface?.network?.id ?:
-                                opts.networkInterfaces.getAt(0)?.network?.id,
+                                opts?.networkInterfaces?.getAt(0)?.network?.id,
         ]
 
         // Check all possible locations for capability profile
@@ -1656,11 +1658,15 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
         // Check all possible locations for node count (for validating cluster configs)
         if (opts?.config?.containsKey('nodeCount')) {
             validationOpts.nodeCount = opts.config.nodeCount
+        } else if (opts?.containsKey('nodeCount')) {
+            validationOpts.nodeCount = opts.nodeCount
         }
 
         // Check all possible locations for template (for validating virtual image configs)
         if (opts?.config?.containsKey('template')) {
             validationOpts.template = opts.config.template
+        } else if (opts?.containsKey('template')) {
+            validationOpts.template = opts.template
         }
 
         return validationOpts

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
@@ -2388,6 +2388,7 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
             computeServer.status = 'provisioned'
             computeServer.statusMessage = resizeError
             computeServer = saveAndGet(computeServer)
+            rtn.success = false
             rtn.setError("${e}")
         }
         return rtn

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
@@ -644,7 +644,6 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
                     if (cloudFiles?.size() == 0) {
                         server.statusMessage = 'Failed to find cloud files'
                         provisionResponse.setError("Cloud files could not be found for ${virtualImage}")
-                        provisionResponse.success = false
                     }
                     def containerImage = [
                             name          : virtualImage.name ?: workload.workloadType.imageCode,
@@ -2384,7 +2383,6 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
             computeServer.status = 'provisioned'
             computeServer.statusMessage = resizeError
             computeServer = saveAndGet(computeServer)
-            rtn.success = false
             rtn.setError("${e}")
         }
         return rtn

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
@@ -644,6 +644,7 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
                     if (cloudFiles?.size() == 0) {
                         server.statusMessage = 'Failed to find cloud files'
                         provisionResponse.setError("Cloud files could not be found for ${virtualImage}")
+                        provisionResponse.success = false
                     }
                     def containerImage = [
                             name          : virtualImage.name ?: workload.workloadType.imageCode,

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
@@ -1635,36 +1635,33 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
      *         node count, and template if available
      */
     static protected Map getValidateServerConfigOptions(Map opts = [:]) {
-        // Build the options map for validating the server config. This is used in both validateHost and
-        // validateWorkload,  so we want to make sure we are checking all possible locations for these
-        // values (top level opts, opts.config, and nested config for network interfaces).
+        // Check all possible locations for network selection
         Map validationOpts = [
                 networkId: opts?.networkInterface?.network?.id ?:
                         opts?.config?.networkInterface?.network?.id ?:
                                 opts.networkInterfaces.getAt(0)?.network?.id,
         ]
 
-        // Check all possible locations for optional capability profile
+        // Check all possible locations for capability profile
         if (opts?.config?.containsKey('scvmmCapabilityProfile')) {
             validationOpts.scvmmCapabilityProfile = opts.config.scvmmCapabilityProfile
         } else if (opts?.containsKey('scvmmCapabilityProfile')) {
             validationOpts.scvmmCapabilityProfile = opts.scvmmCapabilityProfile
         }
 
-        // Check all possible locations for optional node count (for validating cluster configs)
+        // Check all possible locations for node count (for validating cluster configs)
         if (opts?.config?.containsKey('nodeCount')) {
             validationOpts.nodeCount = opts.config.nodeCount
         }
 
-        // Check all possible locations for optional template (for validating virtual image configs)
+        // Check all possible locations for template (for validating virtual image configs)
         if (opts?.config?.containsKey('template')) {
             validationOpts.template = opts.config.template
         }
 
         return validationOpts
     }
-
-
+    
     protected ComputeServer saveAndGet(ComputeServer server) {
         def saveResult = context.async.computeServer.bulkSave([server]).blockingGet()
         def updatedServer

--- a/src/main/resources/scribe/scvmm-instance-type.scribe
+++ b/src/main/resources/scribe/scvmm-instance-type.scribe
@@ -10,7 +10,7 @@ resource "option-type" "provisionType-scvmm-virtual-image" {
   fieldLabel   = "Virtual Image"
   fieldContext = "config"
   fieldGroup   = "SCVMM Options"
-  required     = false
+  required     = true
   enabled      = true
   editable     = true
   global       = false


### PR DESCRIPTION
This PR incorporates validation checks prior to allowing a user to create an INSTANCE or a CLUSTER. The reason for each change is summarized below. Note that consistency with existing logic was maintained where applicable.

### scvmm-instance-type.scribe

* Changed the SCVMM virtual image field from `false` to `true`. A virtual image is required when creating an INSTANCE. If you attempt to create one without an image selected, the creation fails early on with a “Failed to upload image” error.

### ScvmmProvisionProvider.groovy

* The prior `validateWorkload` always returned success without validation. That resulted in NO validation taking place in the CREATE INSTANCE wizard. That defect is fixed by now calling `validateServerConfigOptions` to perform the validation.
* Refactored `validateHost` to call `validateServerConfigOptions` so that it can be shared by both `validateWorkload` and `validateHost`.

### ScvmmApiService.groovy

The following enhancements were added to the `validateServerConfig()` function:

* The `opts` map was checked for the key’s presence before validation. This allows the shared function to be used when that property is not presented to the user.
* Added supported for the `template` property. This enables us to flag the user, on that wizard page, if they try to create an INSTANCE without an image selected.

### validateWorkload when no options selected

Here is a screenshot using the proposed fix.

<img width="904" height="753" alt="image" src="https://github.com/user-attachments/assets/68b31b21-aef4-43ad-9c9f-bce52268533e" />

### validateHost when no options selected

Here is a screenshot using the proposed fix.

<img width="906" height="873" alt="image" src="https://github.com/user-attachments/assets/b1618085-e6c2-4fa6-b0d6-f9d565c0d8b9" />

NOTE: To get Morpheus Core to call `validateHost`, an embedded SCVMM change might be required. That is being investigated separately.
