### PR TITLE
Prefer opts over configMap for SCVMM fields during clone/managed VM reprovision

### DIFF
--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
@@ -709,6 +709,17 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
                 scvmmOpts.imageId = imageId
                 scvmmOpts.server = server
                 scvmmOpts += getScvmmContainerOpts(workload)
+                // For managed/brownfield VMs, container configMap may be stale;
+                // prefer clone request (opts) so user UI selections take precedence.
+                def resolvedCapabilityProfile = opts?.config?.scvmmCapabilityProfile ?: opts?.scvmmCapabilityProfile ?: scvmmOpts.scvmmCapabilityProfile
+                if (resolvedCapabilityProfile) scvmmOpts.scvmmCapabilityProfile = resolvedCapabilityProfile
+                def resolvedNetworkId = opts?.config?.scvmmNetworkId ?: opts?.scvmmNetworkId ?: scvmmOpts.networkId
+                if (resolvedNetworkId) scvmmOpts.networkId = resolvedNetworkId
+                def resolvedNetworkInterfaces = opts?.networkInterfaces ?: scvmmOpts.networkInterfaces ?: []
+                scvmmOpts.networkInterfaces = resolvedNetworkInterfaces
+                if (opts?.config?.scvmmGeneration) scvmmOpts.scvmmGeneration = opts.config.scvmmGeneration
+                def resolvedHostId = opts?.config?.scvmmHostId ?: opts?.scvmmHostId ?: scvmmOpts.hostId
+                if (resolvedHostId) scvmmOpts.hostId = resolvedHostId
                 scvmmOpts.hostname = server.getExternalHostname()
                 scvmmOpts.domainName = server.getExternalDomain()
                 scvmmOpts.fqdn = scvmmOpts.hostname
@@ -1670,7 +1681,8 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
         Map validationOpts = [
                 networkId: opts?.networkInterface?.network?.id ?:
                         opts?.config?.networkInterface?.network?.id ?:
-                                opts?.networkInterfaces?.getAt(0)?.network?.id,
+                                opts?.networkInterfaces?.getAt(0)?.network?.id ?:
+                                        opts?.config?.scvmmNetworkId,
         ]
 
         // Check all possible locations for capability profile

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
@@ -713,9 +713,9 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
                 // prefer clone request (opts) so user UI selections take precedence.
                 def resolvedCapabilityProfile = opts?.config?.scvmmCapabilityProfile ?: opts?.scvmmCapabilityProfile ?: scvmmOpts.scvmmCapabilityProfile
                 if (resolvedCapabilityProfile) scvmmOpts.scvmmCapabilityProfile = resolvedCapabilityProfile
-                def resolvedNetworkId = opts?.config?.scvmmNetworkId ?: opts?.scvmmNetworkId ?: scvmmOpts.networkId
+                def resolvedNetworkId = opts?.config?.scvmmNetworkId ?: opts?.scvmmNetworkId ?: scvmmOpts.containerConfig?.networkId
                 if (resolvedNetworkId) scvmmOpts.networkId = resolvedNetworkId
-                def resolvedNetworkInterfaces = opts?.networkInterfaces ?: scvmmOpts.networkInterfaces ?: []
+                def resolvedNetworkInterfaces = opts?.networkInterfaces ?: scvmmOpts.containerConfig?.networkInterfaces ?: []
                 scvmmOpts.networkInterfaces = resolvedNetworkInterfaces
                 if (opts?.config?.scvmmGeneration) scvmmOpts.scvmmGeneration = opts.config.scvmmGeneration
                 def resolvedHostId = opts?.config?.scvmmHostId ?: opts?.scvmmHostId ?: scvmmOpts.hostId
@@ -1683,6 +1683,7 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
                         opts?.config?.networkInterface?.network?.id ?:
                                 opts?.networkInterfaces?.getAt(0)?.network?.id ?:
                                         opts?.config?.scvmmNetworkId,
+                networkInterfaces: opts?.networkInterfaces ?: [],
         ]
 
         // Check all possible locations for capability profile


### PR DESCRIPTION
For managed/brownfield VMs, the workload configMap reflects values
persisted at instance creation time and may not match what the user
selected on the reprovision form. Ensure opts (the live request) takes
precedence over configMap for scvmmCapabilityProfile, scvmmNetworkId,
scvmmGeneration, scvmmHostId, and networkInterfaces in both
validateHost and runWorkload.

Ports changes from UI repo for PRs:
https://github.com/HPE-EMU/morpheus-ui/pull/3258