### PR TITLE
MORPH-8145: Fix removeWorkload exception to show actual failure on an exception

### DIFF
--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
@@ -1265,7 +1265,7 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
             }
         } catch (e) {
             log.error("removeWorkload error: ${e}", e)
-            response.error = e.message
+            response.msg = e.message
         }
         return response
     }


### PR DESCRIPTION
This PR ensures that exceptions thrown in the `removeWorkload` handler are displayed to the user. Currently, only a generic "unknown error" is displayed.

Before and after videos available here:

https://hpe.atlassian.net/browse/MORPH-8145?focusedCommentId=3296471