### PR TITLE
refresh server host and console host after VM deployment

### DIFF
--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
@@ -1191,6 +1191,30 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
         return rtn
     }
 
+    private void updateServerHost(ComputeServer server, Map scvmmOpts) {
+        try {
+            def serverDetails = apiService.getServerDetails(scvmmOpts, server.externalId)
+            def hostId = serverDetails?.server?.HostId
+            if (hostId) {
+                def hosts = context.services.computeServer.list(
+                    new DataQuery()
+                        .withFilter('cloud.id', server.cloud.id)
+                        .withFilter('computeServerType.code', 'scvmmHypervisor')
+                )
+                def parentServer = hosts?.find { it.externalId == hostId }
+                if (parentServer && server.parentServer?.id != parentServer.id) {
+                    server.parentServer = parentServer
+                    if (server.consoleType == 'vmrdp') {
+                        server.consoleHost = parentServer.name
+                    }
+                    context.services.computeServer.save(server)
+                }
+            }
+        } catch (e) {
+            log.error("updateServerHost error: ${e}", e)
+        }
+    }
+
     /**
      * Issues the remote calls necessary to start a workload element for running.
      * @param workload the Workload we want to start up.
@@ -1296,6 +1320,8 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
 			def newIpAddress = serverDetails.server?.ipAddress
 			def macAddress = serverDetails.server?.macAddress
 			applyComputeServerNetworkIp(fetchedServer, newIpAddress, newIpAddress, 0, macAddress)
+            def hostOpts = fetchScvmmConnectionDetails(fetchedServer)
+            updateServerHost(fetchedServer, hostOpts)
 			return new ServiceResponse<ProvisionResponse>(true, null, null,
 					new ProvisionResponse(privateIp: fetchedServer.internalIp, publicIp: fetchedServer.externalIp, success: true))
 		} else {


### PR DESCRIPTION
After a VM was vMotioned to a different host, the hypervisor console used the stale host name stored at provisioning time. Opening the console failed until an operator manually edited and saved the VM record to force a refresh.

ScvmmProvisionProvider.getServerDetails (the post-deploy lifecycle hook) called applyComputeServerNetworkIp but never called updateServerHost afterward. The consoleHost field was therefore never refreshed from SCVMM after provisioning completed.

morpheus-ui PR: [#3620](https://github.com/HPE-EMU/morpheus-ui/pull/3620)

Source Jira: [MORPH-3567](https://hpe.atlassian.net/browse/MORPH-3567)

UI commit: [07b5f73](https://github.com/HPE-EMU/morpheus-ui/commit/07b5f73490f233a044f1b1dd98b553eccc9eb0e3)