### PR TITLE
MORPH-8169: Propagate createServer failure, during runWorkload, to Morpheus

### DIFF
--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
@@ -170,7 +170,7 @@ class ScvmmApiService {
                 } else if (createData.error?.contains('which includes generation 1')) {
                     rtn.errorMsg = 'The virtual hard disk selected is not compatible with the template which include generation 1 virtual machine functionality.'
                 }
-                throw new Exception("Error in launching VM: ${createData}")
+                throw new Exception("Error in launching VM: ${rtn.errorMsg ?: createData.error}")
             }
 
             server = morpheusContext.services.computeServer.get(opts.serverId)//ComputeServer.get(opts.serverId)
@@ -306,6 +306,9 @@ class ScvmmApiService {
             }
         } catch (e) {
             log.error("createServer error: ${e}", e)
+            if (!rtn.errorMsg) {
+                rtn.errorMsg = e.message
+            }
         }
         return rtn
     }

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
@@ -771,7 +771,26 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
                 log.debug("create server: ${scvmmOpts}")
                 def createResults = apiService.createServer(scvmmOpts)
                 log.debug("createResults: ${createResults}")
+
+                // Must be captured before the success check below. Even when createServer fails, a cloud-init ISO
+                // may have already been created and mounted. cloneParentCleanup() (called in the finally block)
+                // relies on scvmmOpts.deleteDvdOnComplete to clean up that ISO, so it must be set regardless
+                // of whether provisioning ultimately succeeds or fails.
                 scvmmOpts.deleteDvdOnComplete = createResults.deleteDvdOnComplete
+
+                if (!createResults.success) {
+                    log.error("Failed to create server: ${createResults}")
+                    // If SCVMM created the VM but a subsequent step (e.g. getServerDetails) failed, createResults
+                    // will have success=false but still carry the VM's externalId. Bind it to the Morpheus server
+                    // record now so the VM is not orphaned in SCVMM with no corresponding Morpheus reference.
+                    if (createResults.server?.id) {
+                        server.externalId = createResults.server.id
+                    }
+                    server.statusMessage = 'Failed to create server'
+                    context.async.computeServer.save(server).blockingGet()
+                    throw new Exception(createResults.errorMsg as String ?: 'Unknown error creating server')
+                }
+
 				// Adding the deleteDvdOnComplete to the workload config for future reference in the finalize step.
 				// This is done as adding it to scvmmOpts above doesn't persist it anywhere.
 				def workloadConfig = workload.configMap


### PR DESCRIPTION
See [MORPH-8169](https://hpe.atlassian.net/browse/MORPH-8169) for screenshots

## Summary

This PR addresses two provisioning failure scenarios in the SCVMM plugin where errors were either silently swallowed or produced uninformative messages.

## Changes

### `ScvmmProvisionProvider.groovy` — `runWorkload`

**Problem:** When `apiService.createServer()` returned `success=false`, the existing code fell through to the `if (createResults.success == true)` block and did nothing — no error was surfaced, no status was set on the server record, and any cloud-init ISO that had already been created and mounted was leaked.

**Fix:**
- `scvmmOpts.deleteDvdOnComplete` is now captured **before** the success check so that `cloneParentCleanup()` (called in the `finally` block) can always clean up a mounted ISO, regardless of whether provisioning succeeds or fails.
- Added an explicit early failure path: when `createResults.success` is false, the VM's `externalId` is bound to the Morpheus server record (preventing the VM from being orphaned in SCVMM with no corresponding Morpheus reference), `statusMessage` is set to `'Failed to create server'`, the record is persisted, and a meaningful exception containing the actual SCVMM error is thrown.

### `ScvmmApiService.groovy` — `createServer`

**Problem 1:** When the SCVMM VM launch command failed with a known generation-compatibility error, the exception message was `"Error in launching VM: ${createData}"` — which dumped the entire raw response map even when a friendlier, human-readable message had already been constructed.

**Fix:** The exception now uses `"Error in launching VM: ${rtn.errorMsg ?: createData.error}"`, preferring the pre-built friendly message and falling back to the raw SCVMM error string.

**Problem 2:** If `createServer` failed due to an unexpected exception, the caller received `rtn.errorMsg = null`, resulting in `'Unknown error creating server'` being thrown with no useful context.

**Fix:** The `catch` block now sets `rtn.errorMsg = e.message` when no message has already been captured, ensuring the exception detail is always propagated to the caller.