### PR TITLE
MORPH-8169: Propagate createServer failure, during runWorkload, to Morpheus

### DIFF
--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
@@ -170,7 +170,7 @@ class ScvmmApiService {
                 } else if (createData.error?.contains('which includes generation 1')) {
                     rtn.errorMsg = 'The virtual hard disk selected is not compatible with the template which include generation 1 virtual machine functionality.'
                 }
-                throw new Exception("Error in launching VM: ${createData}")
+                throw new Exception("Error in launching VM: ${rtn.errorMsg ?: createData.error}")
             }
 
             server = morpheusContext.services.computeServer.get(opts.serverId)//ComputeServer.get(opts.serverId)
@@ -306,6 +306,9 @@ class ScvmmApiService {
             }
         } catch (e) {
             log.error("createServer error: ${e}", e)
+            if (!rtn.errorMsg) {
+                rtn.errorMsg = e.message
+            }
         }
         return rtn
     }

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
@@ -842,13 +842,17 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
                         }
                         server.statusMessage = 'Failed to create server'
                         context.async.computeServer.save(server).blockingGet()
-                        provisionResponse.success = false
+                        provisionResponse.setError(server.statusMessage)
                     }
-
+                } else {
+                    server.statusMessage = createResults.errorMsg ?: 'Unknown error creating server'
+                    context.async.computeServer.save(server).blockingGet()
+                    provisionResponse.setError(server.statusMessage)
                 }
             } else {
                 server.statusMessage = 'Failed to upload image'
                 context.async.computeServer.save(server).blockingGet()
+                provisionResponse.setError(server.statusMessage)
             }
 
 			if (provisionResponse.success != true) {


### PR DESCRIPTION
The SCVMM `runWorkload`handler calls `apiService.createServer` to create the VM. It does not, however, propagate any failure it receives to Morpheus. This PR addresses this along with several other related defects.

### ScvmmApiService.groovy

The previous code did this:
```groovy
throw new Exception("Error in launching VM: ${createData}")
```

That is incorrect because `createData` is a map and does not convert well into a string. Instead, I have changed it to:
```groovy
throw new Exception("Error in launching VM: ${rtn.errorMsg ?: createData.error}")
```
The existing code uses the `errorMsg` property to return the error string. That is used if present. If not, it uses `createData.error` as the error message since that is what is populated by the Morpheus context `executeWindowsCommand` method.

In addition, in the `catch (e)` handler, if `errorMsg` is not yet set, the exception error string is placed in the return object’s `errorMsg` property.

### ScvmmProvisionProvider.groovy

This is the module where a failure returned by `apiService.createServer` is not returned from the `runWorkload` method. If `createResults.success` is not `true`, we need to set the server’s status message as well as in the return `provisionResponse`. Similar to what you see done in other handlers such as line 843-845.


