### PR TITLE
set save=true when consoleHost changes during VM sync

### DIFF
--- a/src/main/groovy/com/morpheusdata/scvmm/sync/VirtualMachineSync.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/sync/VirtualMachineSync.groovy
@@ -235,6 +235,7 @@ class VirtualMachineSync {
                             }
                             if (currentServer.consoleHost != consoleHost) {
                                 currentServer.consoleHost = consoleHost
+                                save = true
                             }
                             if (currentServer.consolePort != consolePort) {
                                 currentServer.consolePort = consolePort

--- a/src/main/groovy/com/morpheusdata/scvmm/sync/VirtualMachineSync.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/sync/VirtualMachineSync.groovy
@@ -224,10 +224,8 @@ class VirtualMachineSync {
                             def consoleType = consoleEnabled ? 'vmrdp' : null
                             def consolePort = consoleEnabled ? 2179 : null
                             def consoleHost = consoleEnabled ? currentServer.parentServer?.name : null
-                            def consoleUsername = cloud.accountCredentialData?.username ?: cloud.getConfigProperty('username') ?: 'dunno'
-                            if (consoleUsername.contains('\\')) {
-                                consoleUsername = consoleUsername.tokenize('\\')[1]
-                            }
+                            def rawUsername = cloud.accountCredentialData?.username ?: cloud.getConfigProperty('username') ?: 'dunno'
+                            def consoleUsername = rawUsername.contains('\\') ? (rawUsername.tokenize('\\')[1] ?: rawUsername) : rawUsername
                             def consolePassword = cloud.accountCredentialData?.password ?: cloud.getConfigProperty('password')
                             if (currentServer.consoleType != consoleType) {
                                 currentServer.consoleType = consoleType

--- a/src/main/groovy/com/morpheusdata/scvmm/sync/VirtualMachineSync.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/sync/VirtualMachineSync.groovy
@@ -241,7 +241,7 @@ class VirtualMachineSync {
                                 currentServer.consolePort = consolePort
                                 save = true
                             }
-                            /*if (consoleEnabled) {
+                            if (consoleEnabled) {
                                 if (consoleUsername != currentServer.sshUsername) {
                                     currentServer.sshUsername = consoleUsername
                                     save = true
@@ -250,7 +250,7 @@ class VirtualMachineSync {
                                     currentServer.consolePassword = consolePassword
                                     save = true
                                 }
-                            }*/
+                            }
                             // Operating System
                             def osTypeCode = apiService.getMapScvmmOsType(masterItem.OperatingSystem, true, masterItem.OperatingSystemWindows?.toString() == 'true' ? 'windows' : null)
                             def osTypeCodeStr = osTypeCode ?: 'other'


### PR DESCRIPTION
After cloud sync, consoleHost appeared to be set in memory but was silently discarded. Subsequent console connections used a stale or missing host name because the updated value was never written to the database.

In VirtualMachineSync.updateMatchedVirtualMachines, the consoleHost field was assigned when it differed from the current value, but save was not set to true. Because the server is only persisted when save == true, the change was lost on every sync cycle.

morpheus-ui PR: [#4352](https://github.com/HPE-EMU/morpheus-ui/pull/4352)

Source Jira: [MORPH-11002](https://hpe.atlassian.net/browse/MORPH-11002)

UI commit: [0c7a1a6](https://github.com/HPE-EMU/morpheus-ui/commit/0c7a1a6226b3249b33ea5e9c98662466b5628d7e)