### PR TITLE
Remove redundant code to set success to false when setError already took care of it

### DIFF
--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
@@ -642,7 +642,6 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
                     if (cloudFiles?.size() == 0) {
                         server.statusMessage = 'Failed to find cloud files'
                         provisionResponse.setError("Cloud files could not be found for ${virtualImage}")
-                        provisionResponse.success = false
                     }
                     def containerImage = [
                             name          : virtualImage.name ?: workload.workloadType.imageCode,
@@ -2348,7 +2347,6 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
             computeServer.status = 'provisioned'
             computeServer.statusMessage = resizeError
             computeServer = saveAndGet(computeServer)
-            rtn.success = false
             rtn.setError("${e}")
         }
         return rtn


### PR DESCRIPTION
This PR stems from feedback received in a different PR:

> https://github.com/HewlettPackard/morpheus-scvmm-plugin/pull/172#discussion_r3375144778
>
> There are 2/3 places which uses setError still assign success = false, we should clean that up too as part of this PR. I am okay if we want to take that as part of another PR too.

This PR removes the two lines which are unnecessary as `setError` already ensures the `ServiceResponse` success property is set to `false`.