### PR TITLE
Enable hot-add resize for SCVMM VMs

### DIFF
--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmApiService.groovy
@@ -552,6 +552,7 @@ if(\$cloud) {
 						MemoryAssignedMB=\$VM.MemoryAssignedMB
 						DynamicMemoryMinimumMB=\$VM.DynamicMemoryMinimumMB
 						DynamicMemoryMaximumMB=\$VM.DynamicMemoryMaximumMB
+						Generation=\$VM.Generation
 
 					}
 		

--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
@@ -2394,7 +2394,20 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
             rtn.neededCores = (rtn.requestedCores ?: 1) - (currentCores ?: 1)
             setDynamicMemory(rtn, plan)
 
-            rtn.hotResize = false
+            // Determine hot-add capability based on VM generation and dynamic memory
+            def serverObj = server ?: workload?.server
+            if (serverObj?.getConfigProperty('generation') == null) {
+                // Legacy server without generation info — safe default to always stop
+                rtn.hotResize = false
+            } else {
+                def hasDynamicMemory = serverObj?.hotResize == true
+                // Memory hot-add: allowed if no change or dynamic memory is enabled (both gen 1 and gen 2)
+                def memoryHotAdd = (rtn.neededMemory == 0) || (hasDynamicMemory && rtn.neededMemory >= 0)
+                // CPU hot-add: only gen 2, only adding (not removing)
+                def cpuHotAdd = (rtn.neededCores == 0) || (serverObj?.cpuHotResize == true && rtn.neededCores > 0)
+                // Disk operations on SCSI are always hot-addable (both gen 1 and gen 2)
+                rtn.hotResize = memoryHotAdd && cpuHotAdd
+            }
 
             // Disk changes.. see if stop is required
             if (opts.volumes) {

--- a/src/main/groovy/com/morpheusdata/scvmm/sync/VirtualMachineSync.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/sync/VirtualMachineSync.groovy
@@ -6,6 +6,7 @@ import com.morpheusdata.core.data.DataFilter
 import com.morpheusdata.core.data.DataQuery
 import com.morpheusdata.core.providers.CloudProvider
 import com.morpheusdata.core.util.ComputeUtility
+import com.morpheusdata.core.util.MorpheusUtils
 import com.morpheusdata.core.util.SyncTask
 import com.morpheusdata.core.util.SyncUtils
 import com.morpheusdata.model.*
@@ -102,6 +103,10 @@ class VirtualMachineSync {
                 log.debug "Adding new virtual machine: ${cloudItem.Name}"
                 def vmConfig = buildVmConfig(cloudItem, defaultServerType)
                 ComputeServer add = new ComputeServer(vmConfig)
+                if (cloudItem.Generation != null) {
+                    def generation = cloudItem.Generation?.toString() == '2' ? 'generation2' : 'generation1'
+                    add.setConfigProperty('generation', generation)
+                }
                 add.maxStorage = (cloudItem.TotalSize?.toDouble() ?: 0)
                 add.usedStorage = (cloudItem.UsedSize?.toDouble() ?: 0)
                 add.maxMemory = (cloudItem.Memory?.toLong() ?: 0) * 1024l * 1024l
@@ -215,6 +220,25 @@ class VirtualMachineSync {
                             if (currentServer.maxMemory != maxMemory) {
                                 currentServer.maxMemory = maxMemory
                                 save = true
+                            }
+
+                            // Hot-add capabilities based on VM generation and dynamic memory
+                            if (masterItem.Generation != null) {
+                                def isGen2 = masterItem.Generation?.toString() == '2'
+                                def hotResize = MorpheusUtils.parseBooleanConfig(masterItem.DynamicMemoryEnabled)
+                                def generation = isGen2 ? 'generation2' : 'generation1'
+                                if (currentServer.hotResize != hotResize) {
+                                    currentServer.hotResize = hotResize
+                                    save = true
+                                }
+                                if (currentServer.cpuHotResize != isGen2) {
+                                    currentServer.cpuHotResize = isGen2
+                                    save = true
+                                }
+                                if (currentServer.getConfigProperty('generation') != generation) {
+                                    currentServer.setConfigProperty('generation', generation)
+                                    save = true
+                                }
                             }
                             def parentServer = hosts?.find { host -> host.externalId == masterItem.HostId }
                             if (parentServer != null && currentServer.parentServer != parentServer) {
@@ -360,6 +384,8 @@ class VirtualMachineSync {
     }
 
     private buildVmConfig(Map cloudItem, ComputeServerType defaultServerType) {
+        def isGen2 = cloudItem.Generation?.toString() == '2'
+        def hasDynamicMemory = MorpheusUtils.parseBooleanConfig(cloudItem.DynamicMemoryEnabled)
         def vmConfig = [
                 name             : cloudItem.Name,
                 cloud            : cloud,
@@ -369,7 +395,8 @@ class VirtualMachineSync {
                 managed          : false,
                 uniqueId         : cloudItem.ID,
                 provision        : false,
-                hotResize        : false,
+                hotResize        : hasDynamicMemory,
+                cpuHotResize     : isGen2,
                 serverType       : 'vm',
                 lvmEnabled       : false,
                 discovered       : true,


### PR DESCRIPTION
Morpheus unconditionally powered off SCVMM VMs for every resize operation (memory, CPU, disk), even though Hyper-V/SCVMM supports hot-add live for memory (with Dynamic Memory), CPU (Gen 2 only), and disk (SCSI) operations. This forced an avoidable reboot and the red warning shown to end users was easily overlooked.

In ScvmmProvisionProvider.getResizeConfig, hotResize was hardcoded to false. This change replaces that with per-operation hot-add logic driven by VM generation and Dynamic Memory status: memory hot-add is allowed when there is no change or Dynamic Memory is enabled (Gen 1 and Gen 2), CPU hot-add is allowed only when adding cores on Gen 2, and SCSI disk operations are always hot-addable. VM discovery/sync in VirtualMachineSync now captures the VM Generation (via the new Generation field in the ScvmmApiService PowerShell VM list output) and sets the hotResize/cpuHotResize flags accordingly. Legacy VMs without generation metadata safely fall back to the always-stop behavior.

morpheus-ui PR: [#4387](https://github.com/HPE-EMU/morpheus-ui/pull/4387)

Source Jira: [MORPH-11005](https://hpe.atlassian.net/browse/MORPH-11005)

UI commit: [f8426ce](https://github.com/HPE-EMU/morpheus-ui/commit/f8426ce9a93f3e05a6244431edf49d0130a657a5)
