### PR TITLE
Filter available datastores selection based on resource pool for SCVMM instance

### DIFF
--- a/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/ScvmmProvisionProvider.groovy
@@ -1638,6 +1638,25 @@ class ScvmmProvisionProvider extends AbstractProvisionProvider implements Worklo
 		return true
 	}
 
+	/**
+	 * SCVMM supports automatic datastore placement (deploy to the cloud/cluster and let SCVMM
+	 * choose the volume). This keeps the datastore optional rather than required during provisioning.
+	 * @return Boolean
+	 */
+	@Override
+	Boolean supportsAutoDatastore() {
+		return true
+	}
+
+	/**
+	 * The root volume datastore is selectable for SCVMM (per-cluster datastore selection is supported).
+	 * @return Boolean
+	 */
+	@Override
+	Boolean disableRootDatastore() {
+		return false
+	}
+
     @Override
     HostType getHostType() {
         return HostType.vm

--- a/src/main/groovy/com/morpheusdata/scvmm/sync/DatastoresSync.groovy
+++ b/src/main/groovy/com/morpheusdata/scvmm/sync/DatastoresSync.groovy
@@ -123,6 +123,14 @@ class DatastoresSync {
                     existingItem.zonePool = cluster
                     doSave = true
                 }
+                // Scope the datastore to its cluster via assignedZonePools (many-to-many) so it can be
+                // selected per resource pool during provisioning without marking it highly available
+                // (only a singular zonePool implies a clustered shared volume / HA placement).
+                def assignedCluster = cluster ?: host?.resourcePool
+                if (assignedCluster && !existingItem.assignedZonePools?.find { it.id == assignedCluster.id }) {
+                    existingItem.assignedZonePools = (existingItem.assignedZonePools ?: []) + new CloudPool(id: assignedCluster.id)
+                    doSave = true
+                }
                 if (doSave) {
                     def savedDataStore = context.async.cloud.datastore.save(existingItem).blockingGet()
                     if (savedDataStore && host) {
@@ -167,6 +175,13 @@ class DatastoresSync {
                         ]
                 log.debug("datastoreConfig: ${datastoreConfig}")
                 Datastore datastore = new Datastore(datastoreConfig)
+                // Scope the datastore to its cluster via assignedZonePools (many-to-many) so it can be
+                // selected per resource pool during provisioning without marking it highly available
+                // (only a singular zonePool implies a clustered shared volume / HA placement).
+                def assignedCluster = cluster ?: host?.resourcePool
+                if (assignedCluster) {
+                    datastore.assignedZonePools = [new CloudPool(id: assignedCluster.id)]
+                }
                 def savedDataStore = context.async.cloud.datastore.create(datastore).blockingGet()
                 log.debug("savedDataStore?.id: ${savedDataStore?.id}")
                 if (savedDataStore && host) {


### PR DESCRIPTION
When a resource pool is selected, when creating an SCVMM instance under datastore selection, we should only show storage options for that resource pool only 